### PR TITLE
card-588 IE11 layout fixes

### DIFF
--- a/src/view/components/rule-engine/rule-action-component.ts
+++ b/src/view/components/rule-engine/rule-action-component.ts
@@ -17,7 +17,7 @@ import {ServerSideFieldModel} from "../../../api/rule-engine/ServerSideFieldMode
 @Component({
   selector: 'rule-action'})
 @View({
-  template: `<div *ngIf="typeDropdown != null" flex layout="row" layout-align="space-between center" class="cw-rule-action cw-entry">
+  template: `<div *ngIf="typeDropdown != null" flex layout="row" class="cw-rule-action cw-entry">
   <div flex="25" layout="row" class="cw-row-start-area">
     <cw-input-dropdown
       flex

--- a/src/view/components/rule-engine/rule-component.ts
+++ b/src/view/components/rule-engine/rule-component.ts
@@ -38,7 +38,7 @@ var rsrc = {
   selector: 'rule'
 })
 @View({
-  template: `<div flex layout="column" class="cw-rule" [class.cw-hidden]="hidden" [class.cw-disabled]="!rule.enabled">
+  template: `<div class="cw-rule" [class.cw-hidden]="hidden" [class.cw-disabled]="!rule.enabled">
   <div flex layout="row" class="cw-header" *ngIf="!hidden" (click)="toggleCollapsed()">
     <div flex="70" layout="row" layout-align="start center" class="cw-header-info" *ngIf="!hidden">
       <i flex="none" class="caret icon cw-rule-caret large" [class.right]="collapsed" [class.down]="!collapsed" aria-hidden="true"></i>
@@ -87,13 +87,13 @@ var rsrc = {
     </div>
   </div>
   <div flex class="cw-accordion-body" [class.cw-hidden]="collapsed">
-    <condition-group layout="row" *ngFor="var group of groups; var i=index"
+    <condition-group *ngFor="var group of groups; var i=index"
                      [rule]="rule"
                      [group]="group"
                      [groupIndex]="i"
                      (remove)="onConditionGroupRemove($event)"
                      (change)="onConditionGroupChange($event)"></condition-group>
-    <div flex layout="column" class="cw-action-group">
+    <div class="cw-action-group">
       <div flex class="cw-action-separator">
         {{rsrc('inputs.action.firesActions') | async}}
       </div>

--- a/src/view/components/rule-engine/rule-component.ts
+++ b/src/view/components/rule-engine/rule-component.ts
@@ -86,7 +86,7 @@ var rsrc = {
       </div>
     </div>
   </div>
-  <div flex class="cw-accordion-body" [class.cw-hidden]="collapsed">
+  <div class="cw-accordion-body" [class.cw-hidden]="collapsed">
     <condition-group *ngFor="var group of groups; var i=index"
                      [rule]="rule"
                      [group]="group"
@@ -94,12 +94,12 @@ var rsrc = {
                      (remove)="onConditionGroupRemove($event)"
                      (change)="onConditionGroupChange($event)"></condition-group>
     <div class="cw-action-group">
-      <div flex class="cw-action-separator">
+      <div class="cw-action-separator">
         {{rsrc('inputs.action.firesActions') | async}}
       </div>
       <div flex layout="column" class="cw-rule-actions">
-        <div flex layout="row" class="cw-action-row" *ngFor="var ruleAction of actions; #i=index">
-          <rule-action flex [action]="ruleAction" [index]="i" (change)="onActionChange($event)" (remove)="onActionRemove($event)"></rule-action>
+        <div layout="row" class="cw-action-row" *ngFor="var ruleAction of actions; #i=index">
+          <rule-action flex layout="row" [action]="ruleAction" [index]="i" (change)="onActionChange($event)" (remove)="onActionRemove($event)"></rule-action>
           <div class="cw-btn-group cw-add-btn">
             <div class="ui basic icon buttons" *ngIf="i === (actions.length - 1)">
               <button class="cw-button-add-item ui button" arial-label="Add Action" (click)="addAction();" [disabled]="!ruleAction.isPersisted()">

--- a/src/view/components/rule-engine/rule-condition-group-component.ts
+++ b/src/view/components/rule-engine/rule-condition-group-component.ts
@@ -18,10 +18,10 @@ import {ServerSideTypeModel} from "../../../api/rule-engine/ServerSideFieldModel
 })
 @View({
   template: `<div class="cw-rule-group">
-  <div flex class="cw-condition-group-separator" *ngIf="groupIndex === 0">
+  <div class="cw-condition-group-separator" *ngIf="groupIndex === 0">
     {{rsrc.inputs.group.whenConditions.label}}
   </div>
-  <div flex class="cw-condition-group-separator" *ngIf="groupIndex !== 0">
+  <div class="cw-condition-group-separator" *ngIf="groupIndex !== 0">
     <div class="ui basic icon buttons">
       <button class="ui small button cw-group-operator" (click)="toggleGroupOperator()">
         <div>{{group.operator}}</div>

--- a/src/view/components/rule-engine/rule-condition-group-component.ts
+++ b/src/view/components/rule-engine/rule-condition-group-component.ts
@@ -17,7 +17,7 @@ import {ServerSideTypeModel} from "../../../api/rule-engine/ServerSideFieldModel
   selector: 'condition-group'
 })
 @View({
-  template: `<div flex layout="column" class="cw-rule-group">
+  template: `<div class="cw-rule-group">
   <div flex class="cw-condition-group-separator" *ngIf="groupIndex === 0">
     {{rsrc.inputs.group.whenConditions.label}}
   </div>

--- a/src/view/components/rule-engine/rule-engine.ts
+++ b/src/view/components/rule-engine/rule-engine.ts
@@ -17,8 +17,8 @@ const I8N_BASE:string = 'api.sites.ruleengine'
   selector: 'cw-rule-engine'
 })
 @View({
-  template: `<div flex layout="column" class="cw-rule-engine">
-  <div flex layout="column" class="cw-header">
+  template: `<div class="cw-rule-engine">
+  <div class="cw-header">
     <div flex layout="row" layout-align="space-between center">
       <div flex layout="row" layout-align="space-between center" class="ui icon input">
         <i class="filter icon"></i>
@@ -39,7 +39,7 @@ const I8N_BASE:string = 'api.sites.ruleengine'
     </div>
   </div>
 
-  <rule flex layout="row" *ngFor="var r of rules" [rule]="r" [hidden]="isFiltered(r) == true"
+  <rule *ngFor="var r of rules" [rule]="r" [hidden]="isFiltered(r) == true"
         (change)="onRuleChange($event)"
         (remove)="onRuleRemove($event)"></rule>
 </div>

--- a/src/view/components/rule-engine/styles/rule-engine.scss
+++ b/src/view/components/rule-engine/styles/rule-engine.scss
@@ -141,7 +141,7 @@ input.ng-valid.required, input.ng-valid[required], .ui.input input.ng-valid[requ
 
   .cw-condition-row, .cw-action-row {
     margin-bottom: .5em;
-    min-height: 40px;
+    min-height: 1em;
   }
 
   .cw-action-row {

--- a/src/view/components/rule-engine/styles/rule-engine.scss
+++ b/src/view/components/rule-engine/styles/rule-engine.scss
@@ -141,6 +141,7 @@ input.ng-valid.required, input.ng-valid[required], .ui.input input.ng-valid[requ
 
   .cw-condition-row, .cw-action-row {
     margin-bottom: .5em;
+    min-height: 40px;
   }
 
   .cw-action-row {


### PR DESCRIPTION
So while I was working on make this work on IE11 I discover that we don't need parent containers to have ```display: flex```.

So if we have parent containers with ```display: block``` and inside flex containers, the parent grows correctly in IE11 and all others browsers.