### PR TITLE
Adding recently created rule to a bundle, or pushing the rule, is faling

### DIFF
--- a/src/view/components/common/modal-dialog/dialog-component.ts
+++ b/src/view/components/common/modal-dialog/dialog-component.ts
@@ -12,10 +12,10 @@ import {CORE_DIRECTIVES} from "angular2/common";
         <ng-content></ng-content>
       </div>
       <div class="actions">
-        <div class="ui black deny button" (click)="cancel.emit(true)">Cancel</div>
-        <div class="ui positive right labeled icon button" (click)="ok.emit()">{{okButtonText}}
+        <div class="ui positive right labeled icon button" [class.disabled]="!okEnabled" (click)="ok.emit()">{{okButtonText}}
           <i class="checkmark icon"></i>
         </div>
+        <div class="ui black deny button" (click)="cancel.emit(true)">Cancel</div>
       </div>
     </div>
   </div>

--- a/src/view/components/common/push-publish/add-to-bundle-dialog-component.ts
+++ b/src/view/components/common/push-publish/add-to-bundle-dialog-component.ts
@@ -14,7 +14,7 @@ import {IBundle} from "../../../../api/services/bundle-service";
     [okEnabled]="selectedBundle != null"
     [errorMessage]="errorMessage"
     width="25em"
-    height="20em"
+    height="auto"
     (ok)="addToBundle.emit(selectedBundle)"
     (cancel)="cancel.emit()">
   <cw-input-dropdown
@@ -41,7 +41,7 @@ export class AddToBundleDialogComponent {
   @Output() cancel:EventEmitter<boolean> = new EventEmitter(false)
   @Output() addToBundle:EventEmitter<IBundle> = new EventEmitter(false)
 
-  public selectedBundle:IBundle;
+  public selectedBundle:IBundle = null;
 
   constructor() { }
 

--- a/src/view/components/common/push-publish/push-publish-dialog-component.ts
+++ b/src/view/components/common/push-publish/push-publish-dialog-component.ts
@@ -11,10 +11,10 @@ import {IPublishEnvironment} from "../../../../api/services/bundle-service";
     [headerText]="'Push Publish'"
     [okText]="'Push'"
     [hidden]="hidden"
-    [okEnabled]="selectedEnvironment != null"
+    [okEnabled]="selectedEnvironmentId != null"
     [errorMessage]="errorMessage"
     width="25em"
-    height="20em"
+    height="auto"
     (ok)="doPushPublish.emit(selectedEnvironmentId)"
     (cancel)="cancel.emit()">
   <cw-input-dropdown

--- a/src/view/components/rule-engine/rule-component.ts
+++ b/src/view/components/rule-engine/rule-component.ts
@@ -61,12 +61,12 @@ var rsrc = {
     PushPublishDialogContainer],
   template: `<form [ngFormModel]="formModel" #rf="ngForm">
   <cw-add-to-bundle-dialog-container
-      [assetId]="rule.id"
+      [assetId]="rule.id || rule.key"
       [hidden]="!showAddToBundleDialog"
       (close)="showAddToBundleDialog = false; showMoreMenu = false"></cw-add-to-bundle-dialog-container>
   <cw-push-publish-dialog-container
       [environmentStores]="environmentStores"
-      [assetId]="rule.id"
+      [assetId]="rule.id || rule.key"
       [hidden]="!showPushPublishDialog"
       (close)="showPushPublishDialog = false; showMoreMenu = false"></cw-push-publish-dialog-container>
   <div class="cw-rule" [class.cw-hidden]="hidden" [class.cw-disabled]="!rule.enabled" [class.cw-saving]="saving" [class.cw-saved]="saved" [class.cw-out-of-sync]="!saved && !saving">
@@ -118,8 +118,8 @@ var rsrc = {
         </div>
       </div>
       <div class="ui vertical menu" *ngIf="showMoreMenu">
-        <a class="item" (click)="showAddToBundleDialog = true; $event.stopPropagation()">Add to bundle</a>
-        <a class="item" *ngIf="environmentStores.length > 0" (click)="showPushPublishDialog = true; $event.stopPropagation()">Push Publish</a>
+        <a class="item" *ngIf="rule.id || rule.key" (click)="showAddToBundleDialog = true; $event.stopPropagation()">Add to bundle</a>
+        <a class="item" *ngIf="environmentStores.length > 0 && (rule.id || rule.key)" (click)="showPushPublishDialog = true; $event.stopPropagation()">Push Publish</a>
         <a class="item" (click)="deleteRuleClicked($event)">Delete rule</a>
       </div>
     </div>


### PR DESCRIPTION
- Fix push publish and add to bundle modal height
- Hide push and add to bundle options when rule id or key is not defined
- Enable OK button only when environtment or bundle is set (selected)