### PR TITLE
dotCMS/core#13554 Make the layout/code button disabled when the advanced template is not editable

### DIFF
--- a/src/app/api/services/page-view/page-view.service.ts
+++ b/src/app/api/services/page-view/page-view.service.ts
@@ -50,13 +50,24 @@ export class PageViewService {
     }
 
     /**
-     * Get a flag for the type of template in a page
+     * Return type and editability of a page template
      *
      * @param {string} url
-     * @returns {Observable<boolean>}
+     * @returns {Observable<{
+     *         advanced: boolean,
+     *         editable: boolean
+     *     }>}
      * @memberof PageViewService
      */
-    isTemplateAdvanced(url: string): Observable<boolean> {
-        return this.get(url).let(getTemplateTypeFlag);
+    getTemplateState(url: string): Observable<{
+        advanced: boolean,
+        editable: boolean
+    }> {
+        return this.get(url).map((dotPageView: DotPageView) => {
+            return {
+                advanced: !dotPageView.template.drawed,
+                editable: dotPageView.canEditTemplate
+            };
+        });
     }
 }

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.html
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.html
@@ -1,2 +1,2 @@
 <router-outlet></router-outlet>
-<dot-edit-page-nav [advancedTemplate]="isAdvancedTemplate | async"></dot-edit-page-nav>
+<dot-edit-page-nav [templateState]="templateState | async"></dot-edit-page-nav>

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
@@ -68,6 +68,9 @@ describe('DotEditPageMainComponent', () => {
 
     it('should bind correctly advancedTemplate param', () => {
         const nav: DotEditPageNavComponent = fixture.debugElement.query(By.css('dot-edit-page-nav')).componentInstance;
-        expect(nav.advancedTemplate).toBe(true);
+        expect(nav.templateState).toEqual({
+            editable: false,
+            advanced: true
+        });
     });
 });

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
@@ -9,13 +9,16 @@ import { Observable } from 'rxjs/Observable';
     styleUrls: ['./dot-edit-page-main.component.scss']
 })
 export class DotEditPageMainComponent implements OnInit {
-    isAdvancedTemplate: Observable<boolean>;
+    templateState: Observable<{
+        advanced: boolean,
+        editable: boolean
+    }>;
 
     constructor(private route: ActivatedRoute, private pageViewService: PageViewService) {}
 
     ngOnInit() {
-        this.isAdvancedTemplate = this.route.queryParams
+        this.templateState = this.route.queryParams
             .pluck('url')
-            .mergeMap((url: string) => this.pageViewService.isTemplateAdvanced(url));
+            .mergeMap((url: string) => this.pageViewService.getTemplateState(url).do(res => console.log(res)));
     }
 }

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.html
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.html
@@ -5,10 +5,10 @@
             <span class="edit-page-nav__item-text">{{ dotMessageService.get('editpage.toolbar.nav.content') }}</span>
         </a>
     </li>
-    <li>
-        <a class="edit-page-nav__item" routerLinkActive="edit-page-nav__item--active" [routerLink]="['./layout']" [queryParams]="route.queryParams | async">
-            <i class="fa" [ngClass]="{'fa-th-large': !advancedTemplate, 'fa-code': advancedTemplate}"></i>
-            <span class="edit-page-nav__item-text">{{ dotMessageService.get(advancedTemplate ? 'editpage.toolbar.nav.code' : 'editpage.toolbar.nav.layout') }}</span>
+    <li *ngIf="templateState">
+        <a class="edit-page-nav__item" routerLinkActive="edit-page-nav__item--active" [routerLink]="['./layout']" [queryParams]="route.queryParams | async" [class.edit-page-nav__item--disabled]="!templateState.editable && templateState.advanced">
+            <i class="fa" [ngClass]="{'fa-th-large': !templateState.advanced, 'fa-code': templateState.advanced}"></i>
+            <span class="edit-page-nav__item-text">{{ dotMessageService.get(templateState.advanced ? 'editpage.toolbar.nav.code' : 'editpage.toolbar.nav.layout') }}</span>
         </a>
     </li>
 </ul>

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.scss
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.scss
@@ -33,6 +33,14 @@
         font-size: 1.25em;
         margin-bottom: 8px;
     }
+
+    &--disabled,
+    &--disabled:hover {
+        background-color: transparent;
+        cursor: not-allowed;
+        opacity: 0.2;
+        touch-action: none;
+    }
 }
 
 .edit-page-nav__item--active {

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.spec.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.spec.ts
@@ -11,7 +11,8 @@ describe('DotEditPageNavComponent', () => {
 
     const messageServiceMock = new MockDotMessageService({
         'editpage.toolbar.nav.content': 'Content',
-        'editpage.toolbar.nav.layout': 'Layout'
+        'editpage.toolbar.nav.layout': 'Layout',
+        'editpage.toolbar.nav.code': 'Code'
     });
 
     beforeEach(
@@ -35,7 +36,22 @@ describe('DotEditPageNavComponent', () => {
         expect(menuList).not.toBeNull();
     });
 
-    it('should have menu items', () => {
+    it('should have just content item', () => {
+        const menuListItems = fixture.debugElement.queryAll(By.css('.edit-page-nav__item'));
+        expect(menuListItems.length).toEqual(1);
+
+        const labels = ['Content'];
+        menuListItems.forEach((item, index) => {
+            expect(item.nativeElement.textContent).toContain(labels[index]);
+        });
+    });
+
+    it('should have basic menu items', () => {
+        component.templateState = {
+            editable: true,
+            advanced: false
+        };
+        fixture.detectChanges();
         const menuListItems = fixture.debugElement.queryAll(By.css('.edit-page-nav__item'));
         expect(menuListItems.length).toEqual(2);
 
@@ -43,5 +59,32 @@ describe('DotEditPageNavComponent', () => {
         menuListItems.forEach((item, index) => {
             expect(item.nativeElement.textContent).toContain(labels[index]);
         });
+    });
+
+    it('should have code option', () => {
+        component.templateState = {
+            editable: true,
+            advanced: true
+        };
+        fixture.detectChanges();
+
+        const menuListItems = fixture.debugElement.queryAll(By.css('.edit-page-nav__item'));
+        expect(menuListItems.length).toEqual(2);
+
+        const labels = ['Content', 'Code'];
+        menuListItems.forEach((item, index) => {
+            expect(item.nativeElement.textContent).toContain(labels[index]);
+        });
+    });
+
+    it('should have code option disabled', () => {
+        component.templateState = {
+            editable: false,
+            advanced: true
+        };
+        fixture.detectChanges();
+
+        const menuListItems = fixture.debugElement.queryAll(By.css('.edit-page-nav__item'));
+        expect(menuListItems[1].nativeElement.classList).toContain('edit-page-nav__item--disabled');
     });
 });

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.ts
@@ -8,7 +8,7 @@ import { DotMessageService } from '../../../../api/services/dot-messages-service
     styleUrls: ['./dot-edit-page-nav.component.scss']
 })
 export class DotEditPageNavComponent implements OnInit {
-    @Input() advancedTemplate: boolean;
+    @Input() templateState;
 
     constructor(public route: ActivatedRoute, public dotMessageService: DotMessageService) {}
 

--- a/src/app/portlets/dot-edit-page/shared/models/dot-page-view.model.ts
+++ b/src/app/portlets/dot-edit-page/shared/models/dot-page-view.model.ts
@@ -8,4 +8,5 @@ export interface DotPageView {
     containers?: any;
     site?: any;
     template?: DotTemplate;
+    canEditTemplate: boolean;
 }

--- a/src/app/test/page-view.mock.ts
+++ b/src/app/test/page-view.mock.ts
@@ -1,5 +1,25 @@
+import { DotLayout } from './../portlets/dot-edit-page/shared/models/dot-layout.model';
 import { Observable } from 'rxjs/Observable';
 import { DotPageView } from '../portlets/dot-edit-page/shared/models/dot-page-view.model';
+
+export const mockDotLayout: DotLayout = {
+    title: '',
+    header: false,
+    footer: false,
+    sidebar: {
+        location: 'left',
+        width: 'small',
+        containers: [
+            {
+                identifier: 'fc193c82-8c32-4abe-ba8a-49522328c93e',
+                uuid: 'LEGACY_RELATION_TYPE'
+            }
+        ]
+    },
+    body: {
+        rows: []
+    }
+};
 
 export const fakePageView: DotPageView = {
     containers: {
@@ -43,24 +63,7 @@ export const fakePageView: DotPageView = {
         versionType: '',
         title: 'Hello World'
     },
-    layout: {
-        title: '',
-        header: false,
-        footer: false,
-        sidebar: {
-            location: 'left',
-            width: 'small',
-            containers: [
-                {
-                    identifier: 'fc193c82-8c32-4abe-ba8a-49522328c93e',
-                    uuid: 'LEGACY_RELATION_TYPE'
-                }
-            ]
-        },
-        body: {
-            rows: []
-        }
-    },
+    layout: mockDotLayout,
     template: {
         anonymous: true,
         friendlyName: '',
@@ -71,7 +74,8 @@ export const fakePageView: DotPageView = {
         type: '',
         versionType: '',
         drawed: true
-    }
+    },
+    canEditTemplate: true
 };
 
 export class PageViewServiceMock {
@@ -79,7 +83,10 @@ export class PageViewServiceMock {
         return Observable.of(fakePageView);
     }
 
-    isTemplateAdvanced() {
-        return Observable.of(true);
+    getTemplateState() {
+        return Observable.of({
+            editable: false,
+            advanced: true
+        });
     }
 }


### PR DESCRIPTION
The button for the template edit (Layout or Code) should be disable when is an advanced template and the use can't edit it.