### PR TITLE
dotCMS/core#14056 Some bug fixing

### DIFF
--- a/src/app/api/services/dot-workflow/dot-workflow.service.spec.ts
+++ b/src/app/api/services/dot-workflow/dot-workflow.service.spec.ts
@@ -2,7 +2,6 @@ import { DOTTestBed } from '../../../test/dot-test-bed';
 import { DotWorkflowService } from './dot-workflow.service';
 import { MockBackend } from '@angular/http/testing';
 import { ConnectionBackend, ResponseOptions, Response } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
 import { mockWorkflows } from '../../../test/dot-workflow-service.mock';
 
 describe('DotWorkflowService', () => {

--- a/src/app/api/util/clipboard/ClipboardUtil.spec.ts
+++ b/src/app/api/util/clipboard/ClipboardUtil.spec.ts
@@ -2,8 +2,6 @@ import { DotClipboardUtil } from './ClipboardUtil';
 import { DOTTestBed } from '../../../test/dot-test-bed';
 
 describe('DotClipboardUtil', () => {
-    const load = () => {};
-    const keyDown = () => {};
     let service: DotClipboardUtil;
     let injector;
 
@@ -29,7 +27,7 @@ describe('DotClipboardUtil', () => {
 
         service
             .copy('hello-world')
-            .then((res: boolean) => {})
+            .then(() => {})
             .catch((res) => {
                 expect(res).toBe(undefined);
             });

--- a/src/app/portlets/content-types/layout/content-types-layout.component.spec.ts
+++ b/src/app/portlets/content-types/layout/content-types-layout.component.spec.ts
@@ -91,8 +91,7 @@ describe('ContentTypesLayoutComponent', () => {
     });
 
     it('should have a tab-view', () => {
-        const contentType = fixture.debugElement.query(By.css('.content-type'));
-        const pTabView = contentType.query(By.css('p-tabView'));
+        const pTabView = de.query(By.css('p-tabView'));
 
         expect(pTabView).not.toBeNull();
     });

--- a/src/app/portlets/dot-edit-page/components/dot-edit-page-info/dot-edit-page-info.component.spec.ts
+++ b/src/app/portlets/dot-edit-page/components/dot-edit-page-info/dot-edit-page-info.component.spec.ts
@@ -104,7 +104,7 @@ describe('DotEditPageInfoComponent', () => {
         it('should habdle error of copy to clipboard', fakeAsync(() => {
             spyOn(dotGlobalMessageService, 'error');
             spyOn(dotClipboardUtil, 'copy').and.callFake(() => {
-                return new Promise((resolve, reject) => {
+                return new Promise((_resolve, reject) => {
                     reject(true);
                 });
             });

--- a/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -1,10 +1,9 @@
 import { DotDialogService } from '../../../../../api/services/dot-dialog/dot-dialog.service';
-import { Component, OnInit, Input, EventEmitter, Output, ViewChild, ElementRef, SimpleChanges, OnChanges } from '@angular/core';
+import { Component, OnInit, Input, EventEmitter, Output, ViewChild, SimpleChanges, OnChanges } from '@angular/core';
 import { SelectItem, InputSwitch } from 'primeng/primeng';
 import * as _ from 'lodash';
 import { DotEditPageState } from '../../../../../shared/models/dot-edit-page-state/dot-edit-page-state.model';
 import { DotMessageService } from '../../../../../api/services/dot-messages-service';
-import { DotGlobalMessageService } from '../../../../../view/components/_common/dot-global-message/dot-global-message.service';
 import { DotRenderedPageState } from '../../../shared/models/dot-rendered-page-state.model';
 import { PageMode } from '../../../shared/models/page-mode.enum';
 import { DotEditPageInfoComponent } from '../../../components/dot-edit-page-info/dot-edit-page-info.component';
@@ -30,11 +29,7 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges {
 
     private debounceStateSelector = _.debounce((pageState: PageMode) => this.setSelectorState(pageState), 500, { leading: true });
 
-    constructor(
-        public dotMessageService: DotMessageService,
-        private dotGlobalMessageService: DotGlobalMessageService,
-        private dotDialogService: DotDialogService
-    ) {}
+    constructor(public dotMessageService: DotMessageService, private dotDialogService: DotDialogService) {}
 
     ngOnInit() {
         this.dotMessageService
@@ -121,9 +116,9 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges {
 
     private getModeOption(mode: string, pageState: DotRenderedPageState): SelectItem {
         const modeMap = {
-            'edit': this.getEditOption.bind(this),
-            'preview': this.getPreviewOption.bind(this),
-            'live': this.getLiveOption.bind(this)
+            edit: this.getEditOption.bind(this),
+            preview: this.getPreviewOption.bind(this),
+            live: this.getLiveOption.bind(this)
         };
 
         return modeMap[mode](pageState);

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, tick, async } from '@angular/core/testing';
+import { async } from '@angular/core/testing';
 import { DotEditContentHtmlService, DotContentletAction } from './dot-edit-content-html.service';
 import { DotEditContentToolbarHtmlService } from '../html/dot-edit-content-toolbar-html.service';
 import { DotContainerContentletService } from '../dot-container-contentlet.service';
@@ -211,20 +211,6 @@ describe('DotEditContentHtmlService', () => {
 
         expect(firstContainer.height).toEqual(secondContainer.height);
     });
-
-    it(
-        'should bind contentlets events when the html is done',
-        fakeAsync(() => {
-            spyOn(this.dotEditContentHtmlService, 'bindContenletsEvents');
-
-            this.dotEditContentToolbarHtmlService.addContainerToolbar(fakeIframeEl.contentDocument).then(() => {
-                this.dotEditContentHtmlService.bindContenletsEvents();
-            });
-
-            tick();
-            expect(this.dotEditContentHtmlService.bindContenletsEvents).toHaveBeenCalledTimes(1);
-        })
-    );
 
     it('should add contentlet', () => {
         spyOn(this.dotEditContentHtmlService, 'renderAddedContentlet');

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, tick } from '@angular/core/testing';
+import { fakeAsync, tick, async } from '@angular/core/testing';
 import { DotEditContentHtmlService, DotContentletAction } from './dot-edit-content-html.service';
 import { DotEditContentToolbarHtmlService } from '../html/dot-edit-content-toolbar-html.service';
 import { DotContainerContentletService } from '../dot-container-contentlet.service';
@@ -16,6 +16,8 @@ import { Observable } from 'rxjs/Observable';
 import { mockDotLayout } from '../../../../../test/dot-rendered-page.mock';
 
 describe('DotEditContentHtmlService', () => {
+    let fakeDocument: Document;
+
     const fakeHTML = `
         <html>
         <head>
@@ -27,8 +29,20 @@ describe('DotEditContentHtmlService', () => {
         </head>
         <body>
             <div data-dot-object="container" data-dot-identifier="123" data-dot-uuid="456" data-dot-can-add="CONTENT">
-                <div data-dot-object="contentlet" data-dot-identifier="456" data-dot-inode="456" data-dot-type="NewsWidgets" data-dot-basetype="CONTENT">
+                <div
+                    data-dot-object="contentlet"
+                    data-dot-identifier="456"
+                    data-dot-inode="456"
+                    data-dot-type="NewsWidgets"
+                    data-dot-basetype="CONTENT">
                     <div class="large-column">
+                        <div
+                            data-dot-object="vtl-file"
+                            data-dot-inode="345274e0-3bbb-41f1-912c-b398d5745b9a"
+                            data-dot-url="/application/vtl/widgets/news/personalized-news-listing.vtl"
+                            data-dot-can-read="true"
+                            data-dot-can-edit="true">
+                        </div>
                         <h3>This is a title</h3>
                         <p>this is a paragraph</p>
                         <div data-dot-object="edit-content"></div>
@@ -37,7 +51,12 @@ describe('DotEditContentHtmlService', () => {
             </div>
 
             <div data-dot-object="container" data-dot-identifier="321" data-dot-uuid="654" data-dot-can-add="CONTENT">
-                <div data-dot-object="contentlet" data-dot-identifier="456" data-dot-inode="456" data-dot-type="NewsWidgets" data-dot-basetype="CONTENT">
+                <div
+                    data-dot-object="contentlet"
+                    data-dot-identifier="456"
+                    data-dot-inode="456"
+                    data-dot-type="NewsWidgets"
+                    data-dot-basetype="CONTENT">
                     <div class="large-column">
                         <h3>This is a title</h3>
                         <p>this is a paragraph</p>
@@ -61,7 +80,7 @@ describe('DotEditContentHtmlService', () => {
         'editpage.content.container.menu.form': 'Form'
     });
 
-    beforeEach(() => {
+    beforeEach(async(() => {
         this.injector = DOTTestBed.resolveAndCreate([
             DotEditContentHtmlService,
             DotContainerContentletService,
@@ -88,70 +107,88 @@ describe('DotEditContentHtmlService', () => {
             is not a good architecture.
         */
         this.dotEditContentHtmlService.initEditMode(fakeHTML, { nativeElement: fakeIframeEl });
+
+        fakeDocument = fakeIframeEl.contentWindow.document;
+    }));
+
+    describe('document click', () => {
+        it('should open sub menu', () => {
+            const button: HTMLButtonElement = <HTMLButtonElement>fakeDocument.querySelector('[data-dot-object="popup-button"]');
+            button.click();
+            expect(button.nextElementSibling.classList.contains('active')).toBe(true);
+        });
+
+        it('should emit iframe action to add content', () => {
+            this.dotEditContentHtmlService.iframeActions$.subscribe((res) => {
+                expect(res).toEqual({
+                    name: 'add',
+                    container: null,
+                    dataset: button.dataset
+                });
+            });
+            const button: HTMLButtonElement = <HTMLButtonElement>fakeDocument.querySelector('[data-dot-object="popup-menu-item"]');
+            button.click();
+        });
+
+        it('should emit iframe action to edit vtl', () => {
+            this.dotEditContentHtmlService.iframeActions$.subscribe((res) => {
+                expect(res).toEqual({
+                    name: 'code',
+                    container: container.dataset,
+                    dataset: button.dataset
+                });
+            });
+            const button: HTMLButtonElement = <HTMLButtonElement>fakeDocument.querySelector(
+                '.dotedit-contentlet__toolbar [data-dot-object="popup-menu-item"]'
+            );
+            const container = <HTMLElement>button.closest('div[data-dot-object="container"]');
+            button.click();
+        });
+    });
+
+    it('should set same height to containers', () => {
+        const mockLayout = JSON.parse(JSON.stringify(mockDotLayout));
+        mockLayout.body.rows = [
+            {
+                columns: [
+                    {
+                        containers: [
+                            {
+                                identifier: '123',
+                                uuid: '456'
+                            }
+                        ],
+                        leftOffset: 1,
+                        width: 8
+                    },
+                    {
+                        containers: [
+                            {
+                                identifier: '321',
+                                uuid: '654'
+                            }
+                        ],
+                        leftOffset: 1,
+                        width: 8
+                    }
+                ]
+            }
+        ];
+
+        const querySelector1 = [`div[data-dot-object="container"]`, `[data-dot-identifier="123"]`, `[data-dot-uuid="456"]`].join('');
+        const querySelector2 = [`div[data-dot-object="container"]`, `[data-dot-identifier="321"]`, `[data-dot-uuid="654"]`].join('');
+
+        this.dotEditContentHtmlService.setContaintersSameHeight(mockLayout);
+
+        const firstContainer = this.dotEditContentHtmlService.getEditPageDocument().querySelector(querySelector1);
+        const secondContainer = this.dotEditContentHtmlService.getEditPageDocument().querySelector(querySelector2);
+
+        expect(firstContainer.height).toEqual(secondContainer.height);
     });
 
     it(
-        'should bind containers events when the html is done',
-        fakeAsync((): void => {
-            spyOn(this.dotEditContentHtmlService, 'bindContainersEvents');
-
-            this.dotEditContentToolbarHtmlService.addContainerToolbar(fakeIframeEl.contentDocument).then(() => {
-                this.dotEditContentHtmlService.bindContainersEvents();
-            });
-
-            tick();
-            expect(this.dotEditContentHtmlService.bindContainersEvents).toHaveBeenCalledTimes(1);
-        })
-    );
-
-    it(
-        'should set same height to containers',
-        fakeAsync((): void => {
-            const mockLayout = JSON.parse(JSON.stringify(mockDotLayout));
-            mockLayout.body.rows = [
-                {
-                    columns: [
-                        {
-                            containers: [
-                                {
-                                    identifier: '123',
-                                    uuid: '456'
-                                }
-                            ],
-                            leftOffset: 1,
-                            width: 8
-                        },
-                        {
-                            containers: [
-                                {
-                                    identifier: '321',
-                                    uuid: '654'
-                                }
-                            ],
-                            leftOffset: 1,
-                            width: 8
-                        }
-                    ]
-                }
-            ];
-
-            const querySelector1 = [`div[data-dot-object="container"]`, `[data-dot-identifier="123"]`, `[data-dot-uuid="456"]`].join('');
-
-            const querySelector2 = [`div[data-dot-object="container"]`, `[data-dot-identifier="321"]`, `[data-dot-uuid="654"]`].join('');
-
-            this.dotEditContentHtmlService.setContaintersSameHeight(mockLayout);
-            tick();
-
-            const firstContainer = this.dotEditContentHtmlService.getEditPageDocument().querySelector(querySelector1);
-            const secondContainer = this.dotEditContentHtmlService.getEditPageDocument().querySelector(querySelector2);
-
-            expect(firstContainer.height).toEqual(secondContainer.height);
-        })
-    );
-
-    it(
         'should bind contentlets events when the html is done',
-        fakeAsync((): void => {
+        fakeAsync(() => {
             spyOn(this.dotEditContentHtmlService, 'bindContenletsEvents');
 
             this.dotEditContentToolbarHtmlService.addContainerToolbar(fakeIframeEl.contentDocument).then(() => {
@@ -226,8 +263,7 @@ describe('DotEditContentHtmlService', () => {
     it('should handle edit-content from iframe click', () => {
         const editEl = fakeIframeEl.contentWindow.document.querySelector('[data-dot-object="edit-content"]');
 
-
-        this.dotEditContentHtmlService.iframeActions$.subscribe(res => {
+        this.dotEditContentHtmlService.iframeActions$.subscribe((res) => {
             expect(JSON.parse(JSON.stringify(res))).toEqual({
                 name: 'edit',
                 dataset: {

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -27,7 +27,7 @@ describe('DotEditContentHtmlService', () => {
         </head>
         <body>
             <div data-dot-object="container" data-dot-identifier="123" data-dot-uuid="456" data-dot-can-add="CONTENT">
-                <div data-dot-object="contentlet" data-dot-identifier="456" data-dot-inode="456">
+                <div data-dot-object="contentlet" data-dot-identifier="456" data-dot-inode="456" data-dot-type="NewsWidgets" data-dot-basetype="CONTENT">
                     <div class="large-column">
                         <h3>This is a title</h3>
                         <p>this is a paragraph</p>
@@ -37,7 +37,7 @@ describe('DotEditContentHtmlService', () => {
             </div>
 
             <div data-dot-object="container" data-dot-identifier="321" data-dot-uuid="654" data-dot-can-add="CONTENT">
-                <div data-dot-object="contentlet" data-dot-identifier="456" data-dot-inode="456">
+                <div data-dot-object="contentlet" data-dot-identifier="456" data-dot-inode="456" data-dot-type="NewsWidgets" data-dot-basetype="CONTENT">
                     <div class="large-column">
                         <h3>This is a title</h3>
                         <p>this is a paragraph</p>
@@ -246,7 +246,9 @@ describe('DotEditContentHtmlService', () => {
 
         expect(this.dotEditContentHtmlService.currentContentlet).toEqual({
             identifier: '456',
-            inode: '456'
+            inode: '456',
+            type: 'NewsWidgets',
+            baseType: 'CONTENT'
         });
     });
 

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -15,7 +15,7 @@ import { DotPageContent } from '../../../../dot-edit-page/shared/models/dot-page
 import { Observable } from 'rxjs/Observable';
 import { mockDotLayout } from '../../../../../test/dot-rendered-page.mock';
 
-describe('DotEditContentHtmlService', () => {
+fdescribe('DotEditContentHtmlService', () => {
     let fakeDocument: Document;
 
     const fakeHTML = `
@@ -279,7 +279,9 @@ describe('DotEditContentHtmlService', () => {
             expect(JSON.parse(JSON.stringify(res))).toEqual({
                 name: 'edit',
                 dataset: {
-                    dotObject: 'edit-content'
+                    dotObject: 'edit-content',
+                    dotIdentifier: '456',
+                    dotInode: '456'
                 },
                 container: {
                     dotCanAdd: 'CONTENT',

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -15,7 +15,7 @@ import { DotPageContent } from '../../../../dot-edit-page/shared/models/dot-page
 import { Observable } from 'rxjs/Observable';
 import { mockDotLayout } from '../../../../../test/dot-rendered-page.mock';
 
-fdescribe('DotEditContentHtmlService', () => {
+describe('DotEditContentHtmlService', () => {
     let fakeDocument: Document;
 
     const fakeHTML = `

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -130,6 +130,32 @@ describe('DotEditContentHtmlService', () => {
             button.click();
         });
 
+        it('should emit iframe action to edit content', () => {
+            this.dotEditContentHtmlService.iframeActions$.subscribe((res) => {
+                expect(res).toEqual({
+                    name: 'edit',
+                    container: container.dataset,
+                    dataset: button.dataset
+                });
+            });
+            const button: HTMLButtonElement = <HTMLButtonElement>fakeDocument.querySelector('.dotedit-contentlet__edit');
+            const container = <HTMLElement>button.closest('div[data-dot-object="container"]');
+            button.click();
+        });
+
+        it('should emit iframe action to remove content', () => {
+            this.dotEditContentHtmlService.iframeActions$.subscribe((res) => {
+                expect(res).toEqual({
+                    name: 'remove',
+                    container: container.dataset,
+                    dataset: button.dataset
+                });
+            });
+            const button: HTMLButtonElement = <HTMLButtonElement>fakeDocument.querySelector('.dotedit-contentlet__remove');
+            const container = <HTMLElement>button.closest('div[data-dot-object="container"]');
+            button.click();
+        });
+
         it('should emit iframe action to edit vtl', () => {
             this.dotEditContentHtmlService.iframeActions$.subscribe((res) => {
                 expect(res).toEqual({

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -261,7 +261,6 @@ export class DotEditContentHtmlService {
 
         this.docClickSubscription = Observable.fromEvent(doc, 'click').subscribe(($event: MouseEvent) => {
             const target = <HTMLElement>$event.target;
-
             const method = this.docClickHandlers[target.dataset.dotObject];
             if (method) {
                 method(target);
@@ -287,6 +286,10 @@ export class DotEditContentHtmlService {
         this.docClickHandlers['edit-content'] = (target: HTMLElement) => {
             this.currentContentlet = this.getCurrentContentlet(target);
             this.buttonClickHandler(target, 'edit');
+        };
+
+        this.docClickHandlers['remove-content'] = (target: HTMLElement) => {
+            this.buttonClickHandler(target, 'remove');
         };
 
         this.docClickHandlers['popup-button'] = (target: HTMLElement) => {
@@ -359,7 +362,7 @@ export class DotEditContentHtmlService {
         this.dotEditContentToolbarHtmlService
             .addContentletMarkup(doc)
             .then(() => {
-                this.bindContenletsEvents();
+                // this.bindContenletsEvents();
             })
             .catch((error) => {
                 this.loggerService.debug(error);

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -7,8 +7,6 @@ import { take } from 'rxjs/operators/take';
 
 import * as _ from 'lodash';
 
-import { LoggerService } from 'dotcms-js/dotcms-js';
-
 import { DotContainerContentletService } from '../dot-container-contentlet.service';
 import { DotDOMHtmlUtilService } from '../html/dot-dom-html-util.service';
 import { DotDialogService } from '../../../../../api/services/dot-dialog/dot-dialog.service';
@@ -49,7 +47,6 @@ export class DotEditContentHtmlService {
         private dotDragDropAPIHtmlService: DotDragDropAPIHtmlService,
         private dotEditContentToolbarHtmlService: DotEditContentToolbarHtmlService,
         private dotDOMHtmlUtilService: DotDOMHtmlUtilService,
-        private loggerService: LoggerService,
         private dotDialogService: DotDialogService,
         private dotMessageService: DotMessageService
     ) {
@@ -351,22 +348,8 @@ export class DotEditContentHtmlService {
 
     private addContentToolBars(): void {
         const doc = this.getEditPageDocument();
-
-        this.dotEditContentToolbarHtmlService
-            .addContainerToolbar(doc)
-            .then(() => {})
-            .catch((error) => {
-                this.loggerService.debug(error);
-            });
-
-        this.dotEditContentToolbarHtmlService
-            .addContentletMarkup(doc)
-            .then(() => {
-                // this.bindContenletsEvents();
-            })
-            .catch((error) => {
-                this.loggerService.debug(error);
-            });
+        this.dotEditContentToolbarHtmlService.addContainerToolbar(doc);
+        this.dotEditContentToolbarHtmlService.addContentletMarkup(doc);
     }
 
     private appendNewContentlets(contentletContentEl: any, html: string): void {
@@ -396,11 +379,6 @@ export class DotEditContentHtmlService {
         });
     }
 
-    private bindContenletsEvents(): void {
-        this.bindEditContentletEvents();
-        this.bindRemoveContentletEvents();
-    }
-
     private bindButtonsEvent(button: HTMLElement, type: string): void {
         button.addEventListener('click', ($event: MouseEvent) => {
             this.buttonClickHandler(<HTMLElement>$event.target, type);
@@ -424,24 +402,6 @@ export class DotEditContentHtmlService {
             if (activeElement !== toolbar) {
                 toolbar.classList.remove('active');
             }
-        });
-    }
-
-    private bindEditContentletEvents(): void {
-        const editButtons = Array.from(
-            this.getEditPageDocument().querySelectorAll('.dotedit-contentlet__edit:not(.dotedit-contentlet__disabled)')
-        );
-
-        editButtons.forEach((button: HTMLElement) => {
-            this.bindButtonsEvent(button, 'edit');
-        });
-    }
-
-    private bindRemoveContentletEvents(): void {
-        const removeButtons = Array.from(this.getEditPageDocument().querySelectorAll('.dotedit-contentlet__remove'));
-
-        removeButtons.forEach((button: HTMLElement) => {
-            this.bindButtonsEvent(button, 'remove');
         });
     }
 

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -1,22 +1,28 @@
-import * as _ from 'lodash';
-import { LoggerService } from 'dotcms-js/dotcms-js';
 import { Injectable, ElementRef } from '@angular/core';
-import { EDIT_PAGE_CSS } from '../../shared/iframe-edit-mode.css';
-import { DotContainerContentletService } from '../dot-container-contentlet.service';
-import { DotDragDropAPIHtmlService } from '../html/dot-drag-drop-api-html.service';
-import { GOOGLE_FONTS } from '../html/iframe-edit-mode.js';
-import { DotEditContentToolbarHtmlService } from '../html/dot-edit-content-toolbar-html.service';
-import { DotDOMHtmlUtilService } from '../html/dot-dom-html-util.service';
-import { MODEL_VAR_NAME } from '../html/iframe-edit-mode.js';
+
+import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
-import { DotPageContainer } from '../../../shared/models/dot-page-container.model';
-import { DotPageContent } from '../../../shared/models/dot-page-content.model';
+import { Subscription } from 'rxjs/Subscription';
+import { take } from 'rxjs/operators/take';
+
+import * as _ from 'lodash';
+
+import { LoggerService } from 'dotcms-js/dotcms-js';
+
+import { DotContainerContentletService } from '../dot-container-contentlet.service';
+import { DotDOMHtmlUtilService } from '../html/dot-dom-html-util.service';
 import { DotDialogService } from '../../../../../api/services/dot-dialog/dot-dialog.service';
-import { DotMessageService } from '../../../../../api/services/dot-messages-service';
+import { DotDragDropAPIHtmlService } from '../html/dot-drag-drop-api-html.service';
+import { DotEditContentToolbarHtmlService } from '../html/dot-edit-content-toolbar-html.service';
 import { DotLayout } from '../../../shared/models/dot-layout.model';
 import { DotLayoutColumn } from '../../../shared/models/dot-layout-column.model';
 import { DotLayoutRow } from '../../../shared/models/dot-layout-row.model';
-import { take } from 'rxjs/operators/take';
+import { DotMessageService } from '../../../../../api/services/dot-messages-service';
+import { DotPageContainer } from '../../../shared/models/dot-page-container.model';
+import { DotPageContent } from '../../../shared/models/dot-page-content.model';
+import { EDIT_PAGE_CSS } from '../../shared/iframe-edit-mode.css';
+import { GOOGLE_FONTS } from '../html/iframe-edit-mode.js';
+import { MODEL_VAR_NAME } from '../html/iframe-edit-mode.js';
 
 export enum DotContentletAction {
     EDIT,
@@ -34,6 +40,7 @@ export class DotEditContentHtmlService {
 
     private currentAction: DotContentletAction;
     private rowsMaxHeight: number[] = [];
+    private docClickSubscription: Subscription;
 
     private readonly docClickHandlers;
 
@@ -248,7 +255,11 @@ export class DotEditContentHtmlService {
     private bindGlobalEvents(): void {
         const doc = this.getEditPageDocument();
 
-        doc.addEventListener('click', ($event: MouseEvent) => {
+        if (this.docClickSubscription) {
+            this.docClickSubscription.unsubscribe();
+        }
+
+        this.docClickSubscription = Observable.fromEvent(doc, 'click').subscribe(($event: MouseEvent) => {
             const target = <HTMLElement>$event.target;
 
             const method = this.docClickHandlers[target.dataset.dotObject];

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -212,7 +212,7 @@ export class DotEditContentHtmlService {
         const debounceContainersHeightChange = _.debounce((layout: DotLayout) => this.setContaintersSameHeight(layout), 500, {
             leading: true
         });
-        const observer = new MutationObserver((mutations) => {
+        const observer = new MutationObserver(() => {
             debounceContainersHeightChange(pageLayout);
         });
         observer.observe(target, config);
@@ -283,9 +283,7 @@ export class DotEditContentHtmlService {
         };
 
         this.docClickHandlers['popup-menu-item'] = (target: HTMLElement) => {
-            const parentContentlet = <HTMLElement>target.closest('div[data-dot-object="contentlet"]');
             this.currentContentlet = this.getCurrentContentlet(target);
-
             this.buttonClickHandler(target, target.dataset.dotAction);
         };
     }
@@ -343,9 +341,7 @@ export class DotEditContentHtmlService {
 
         this.dotEditContentToolbarHtmlService
             .addContainerToolbar(doc)
-            .then(() => {
-                // this.bindContainersEvents();
-            })
+            .then(() => {})
             .catch((error) => {
                 this.loggerService.debug(error);
             });
@@ -360,7 +356,7 @@ export class DotEditContentHtmlService {
             });
     }
 
-    private appendNewContentlets(contentletEl: any, html: string): void {
+    private appendNewContentlets(contentletContentEl: any, html: string): void {
         const doc = this.getEditPageDocument();
 
         // Add innerHTML to a plain so we can get the HTML nodes later
@@ -379,10 +375,10 @@ export class DotEditContentHtmlService {
                     script.text = node.textContent;
                 }
 
-                contentletEl.appendChild(script);
+                contentletContentEl.appendChild(script);
             } else {
                 node.removeAttribute('data-dot-object');
-                contentletEl.appendChild(node);
+                contentletContentEl.appendChild(node);
             }
         });
     }
@@ -405,28 +401,6 @@ export class DotEditContentHtmlService {
             name: type,
             dataset: target.dataset,
             container: container ? container.dataset : null
-        });
-    }
-
-    private bindContainersEvents(): void {
-        const addButtons = Array.from(this.getEditPageDocument().querySelectorAll('.dotedit-menu__button:not([disabled])'));
-
-        addButtons.forEach((button: HTMLElement) => {
-            const menuList = button.nextElementSibling;
-            const menuItems = Array.from(menuList.querySelectorAll('.dotedit-menu__item a'));
-
-            this.bindEventToSubMenu(button);
-
-            menuItems.forEach((menuItem: HTMLElement) => {
-                this.bindButtonsEvent(menuItem, menuItem.dataset.dotAction);
-            });
-        });
-    }
-
-    private bindEventToSubMenu(button: HTMLElement): void {
-        button.addEventListener('click', (_event) => {
-            this.closeContainersToolBarMenu(button.nextElementSibling);
-            button.nextElementSibling.classList.toggle('active');
         });
     }
 

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -262,14 +262,19 @@ export class DotEditContentHtmlService {
         });
     }
 
+    private getCurrentContentlet(target: HTMLElement): DotPageContent {
+        const contentlet = <HTMLElement>target.closest('div[data-dot-object="contentlet"]');
+        return {
+            identifier: contentlet.dataset.dotIdentifier,
+            inode: contentlet.dataset.dotInode,
+            type: contentlet.dataset.dotType,
+            baseType: contentlet.dataset.dotBasetype,
+        };
+    }
+
     private setGlobalClickHandlers(): void {
         this.docClickHandlers['edit-content'] = (target: HTMLElement) => {
-            const parentContentlet = <HTMLElement>target.closest('div[data-dot-object="contentlet"]');
-            this.currentContentlet = {
-                identifier: parentContentlet.dataset.dotIdentifier,
-                inode: parentContentlet.dataset.dotInode
-            };
-
+            this.currentContentlet = this.getCurrentContentlet(target);
             this.buttonClickHandler(target, 'edit');
         };
 
@@ -278,6 +283,9 @@ export class DotEditContentHtmlService {
         };
 
         this.docClickHandlers['popup-menu-item'] = (target: HTMLElement) => {
+            const parentContentlet = <HTMLElement>target.closest('div[data-dot-object="contentlet"]');
+            this.currentContentlet = this.getCurrentContentlet(target);
+
             this.buttonClickHandler(target, target.dataset.dotAction);
         };
     }

--- a/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -294,7 +294,6 @@ export class DotEditContentHtmlService {
         };
 
         this.docClickHandlers['popup-menu-item'] = (target: HTMLElement) => {
-            this.currentContentlet = this.getCurrentContentlet(target);
             this.buttonClickHandler(target, target.dataset.dotAction);
         };
     }

--- a/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
+++ b/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
@@ -200,7 +200,7 @@ describe('DotEditContentToolbarHtmlService', () => {
                 it('should have submenu link', () => {
                     const links = testDoc.querySelectorAll('.dotedit-menu__item a');
                     expect(links.length).toEqual(1);
-                    expect(links[0].textContent).toEqual('personalized-news-listing.vtl');
+                    expect(links[0].textContent.trim()).toEqual('personalized-news-listing.vtl');
                 });
             });
 

--- a/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
@@ -92,9 +92,9 @@ export class DotEditContentToolbarHtmlService {
                                 const contentletToolbar = document.createElement('div');
                                 contentletToolbar.classList.add('dotedit-contentlet__toolbar');
 
-                                (this.dragLabel = messages['editpage.content.contentlet.menu.drag']),
-                                    (this.editLabel = messages['editpage.content.contentlet.menu.edit']),
-                                    (this.removeLabel = messages['editpage.content.contentlet.menu.remove']);
+                                this.dragLabel = messages['editpage.content.contentlet.menu.drag'];
+                                this.editLabel = messages['editpage.content.contentlet.menu.edit'];
+                                this.removeLabel = messages['editpage.content.contentlet.menu.remove'];
 
                                 const vtls = Array.from(contentlet.querySelectorAll('div[data-dot-object="vtl-file"]'));
 
@@ -137,12 +137,14 @@ export class DotEditContentToolbarHtmlService {
         let editButtonClass = 'dotedit-contentlet__edit';
         editButtonClass += !canEdit ? ' dotedit-contentlet__disabled' : '';
 
-        return `${this.dotDOMHtmlUtilService.getButtomHTML(this.dragLabel, 'dotedit-contentlet__drag', dataset)}
+        return `
+            ${this.dotDOMHtmlUtilService.getButtomHTML(this.dragLabel, 'dotedit-contentlet__drag', dataset)}
             ${this.dotDOMHtmlUtilService.getButtomHTML(this.editLabel, editButtonClass, dataset)}
-            ${this.dotDOMHtmlUtilService.getButtomHTML(this.removeLabel, 'dotedit-contentlet__remove', dataset)}`;
+            ${this.dotDOMHtmlUtilService.getButtomHTML(this.removeLabel, 'dotedit-contentlet__remove', dataset)}
+        `;
     }
 
-    private getEditVtlButtons(vtls: any[]): string {
+    getEditVtlButtons(vtls: any[]): string {
         return this.getDotEditPopupMenuHtml({
             button: {
                 label: this.dotMessageService.get('editpage.content.container.action.edit.vtl'),
@@ -205,6 +207,7 @@ export class DotEditContentToolbarHtmlService {
     private getDotEditPopupMenuButton(button: DotEditPopupButton, disabled = false): string {
         return `
             <button
+                data-dot-object="popup-button"
                 type="button"
                 class="dotedit-menu__button ${button.class ? button.class : ''}"
                 aria-label="${button.label}"
@@ -220,7 +223,12 @@ export class DotEditContentToolbarHtmlService {
                     .map((item: DotEditPopupMenuItem) => {
                         return `
                             <li class="dotedit-menu__item ${item.disabled ? 'dotedit-menu__item--disabled' : ''}">
-                                <a href="#" ${this.getDotEditPopupMenuItemDataSet(item.dataset)} role="button">${item.label}</a>
+                                <a
+                                    href="#"
+                                    data-dot-object="popup-menu-item"
+                                    ${this.getDotEditPopupMenuItemDataSet(item.dataset)} role="button">
+                                    ${item.label}
+                                </a>
                             </li>
                         `;
                     })

--- a/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
@@ -139,8 +139,14 @@ export class DotEditContentToolbarHtmlService {
 
         return `
             ${this.dotDOMHtmlUtilService.getButtomHTML(this.dragLabel, 'dotedit-contentlet__drag', dataset)}
-            ${this.dotDOMHtmlUtilService.getButtomHTML(this.editLabel, editButtonClass, dataset)}
-            ${this.dotDOMHtmlUtilService.getButtomHTML(this.removeLabel, 'dotedit-contentlet__remove', dataset)}
+            ${this.dotDOMHtmlUtilService.getButtomHTML(this.editLabel, editButtonClass, {
+                ...dataset,
+                'dot-object': 'edit-content'
+            })}
+            ${this.dotDOMHtmlUtilService.getButtomHTML(this.removeLabel, 'dotedit-contentlet__remove', {
+                ...dataset,
+                'dot-object': 'remove-content'
+            })}
         `;
     }
 

--- a/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
@@ -25,107 +25,80 @@ interface DotEditPopupMenu {
  */
 @Injectable()
 export class DotEditContentToolbarHtmlService {
-    private dragLabel: string;
-    private removeLabel: string;
-    private editLabel: string;
-
     constructor(private dotMessageService: DotMessageService, private dotDOMHtmlUtilService: DotDOMHtmlUtilService) {}
 
-    addContainerToolbar(doc: any): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.dotMessageService
-                .getMessages([
-                    'editpage.content.container.action.add',
-                    'editpage.content.container.menu.content',
-                    'editpage.content.container.menu.widget',
-                    'editpage.content.container.menu.form'
-                ])
-                .subscribe(
-                    (messages: string[]) => {
-                        if (messages.length === 0) {
-                            reject();
-                        }
+    /**
+     * Add custom HTML buttons to the containers div
+     *
+     * @param {Document} doc
+     * @memberof DotEditContentToolbarHtmlService
+     */
+    addContainerToolbar(doc: Document): void {
+        this.dotMessageService
+            .getMessages([
+                'editpage.content.container.action.add',
+                'editpage.content.container.menu.content',
+                'editpage.content.container.menu.widget',
+                'editpage.content.container.menu.form'
+            ])
+            .subscribe(() => {
+                const containers = Array.from(doc.querySelectorAll('div[data-dot-object="container"]'));
+                containers.forEach((container: HTMLElement) => {
+                    const containerToolbar = document.createElement('div');
+                    containerToolbar.classList.add('dotedit-container__toolbar');
 
-                        try {
-                            const containers = Array.from(doc.querySelectorAll('div[data-dot-object="container"]'));
-                            containers.forEach((container: HTMLElement) => {
-                                const containerToolbar = document.createElement('div');
-                                containerToolbar.classList.add('dotedit-container__toolbar');
-
-                                if (!container.dataset.dotCanAdd.length) {
-                                    container.classList.add('disabled');
-                                }
-
-                                containerToolbar.innerHTML = this.getContainerToolbarHtml(container);
-                                container.parentNode.insertBefore(containerToolbar, container);
-                            });
-                            resolve();
-                        } catch (error) {
-                            reject(error);
-                        }
-                    },
-                    (error) => {
-                        reject(error);
+                    if (!container.dataset.dotCanAdd.length) {
+                        container.classList.add('disabled');
                     }
-                );
-        });
+
+                    containerToolbar.innerHTML = this.getContainerToolbarHtml(container);
+                    container.parentNode.insertBefore(containerToolbar, container);
+                });
+            });
     }
 
-    addContentletMarkup(doc: any): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.dotMessageService
-                .getMessages([
-                    'editpage.content.container.action.edit.vtl',
-                    'editpage.content.contentlet.menu.drag',
-                    'editpage.content.contentlet.menu.edit',
-                    'editpage.content.contentlet.menu.remove'
-                ])
-                .subscribe(
-                    (messages: any) => {
-                        if (!Object.keys(messages).length) {
-                            reject();
-                        }
+    /**
+     * Edit contentlet html to add button and content
+     *
+     * @param {Document} doc
+     * @memberof DotEditContentToolbarHtmlService
+     */
+    addContentletMarkup(doc: Document): void {
+        this.dotMessageService
+            .getMessages([
+                'editpage.content.container.action.edit.vtl',
+                'editpage.content.contentlet.menu.drag',
+                'editpage.content.contentlet.menu.edit',
+                'editpage.content.contentlet.menu.remove'
+            ])
+            .subscribe(() => {
+                const contentlets = Array.from(doc.querySelectorAll('div[data-dot-object="contentlet"]'));
 
-                        try {
-                            const contentlets = Array.from(doc.querySelectorAll('div[data-dot-object="contentlet"]'));
-                            contentlets.forEach((contentlet: HTMLElement) => {
-                                const contentletToolbar = document.createElement('div');
-                                contentletToolbar.classList.add('dotedit-contentlet__toolbar');
+                contentlets.forEach((contentlet: HTMLElement) => {
+                    const contentletToolbar = document.createElement('div');
+                    contentletToolbar.classList.add('dotedit-contentlet__toolbar');
 
-                                this.dragLabel = messages['editpage.content.contentlet.menu.drag'];
-                                this.editLabel = messages['editpage.content.contentlet.menu.edit'];
-                                this.removeLabel = messages['editpage.content.contentlet.menu.remove'];
+                    const vtls = Array.from(contentlet.querySelectorAll('div[data-dot-object="vtl-file"]'));
 
-                                const vtls = Array.from(contentlet.querySelectorAll('div[data-dot-object="vtl-file"]'));
-
-                                if (vtls.length) {
-                                    contentletToolbar.innerHTML += this.getEditVtlButtons(vtls);
-                                }
-
-                                contentletToolbar.innerHTML += this.getContentButton(
-                                    contentlet.dataset.dotIdentifier,
-                                    contentlet.dataset.dotInode,
-                                    contentlet.dataset.dotCanEdit === 'true'
-                                );
-
-                                const contentletContent = document.createElement('div');
-                                contentletContent.classList.add('dotedit-contentlet__content');
-                                contentletContent.innerHTML = contentlet.innerHTML;
-                                contentlet.innerHTML = '';
-
-                                contentlet.insertAdjacentElement('afterbegin', contentletContent);
-                                contentlet.insertAdjacentElement('afterbegin', contentletToolbar);
-                            });
-                            resolve();
-                        } catch (error) {
-                            reject(error);
-                        }
-                    },
-                    (error) => {
-                        reject(error);
+                    if (vtls.length) {
+                        contentletToolbar.innerHTML += this.getEditVtlButtons(vtls);
                     }
-                );
-        });
+
+                    contentletToolbar.innerHTML += this.getContentButton(
+                        contentlet.dataset.dotIdentifier,
+                        contentlet.dataset.dotInode,
+                        contentlet.dataset.dotCanEdit === 'true'
+                    );
+
+                    const contentletContent = document.createElement('div');
+                    contentletContent.classList.add('dotedit-contentlet__content');
+                    contentletContent.innerHTML = contentlet.innerHTML;
+                    contentlet.innerHTML = '';
+
+                    contentlet.insertAdjacentElement('afterbegin', contentletContent);
+                    contentlet.insertAdjacentElement('afterbegin', contentletToolbar);
+                });
+            });
     }
 
     getContentButton(identifier: string, inode: string, canEdit?: boolean): string {
@@ -138,15 +111,30 @@ export class DotEditContentToolbarHtmlService {
         editButtonClass += !canEdit ? ' dotedit-contentlet__disabled' : '';
 
         return `
-            ${this.dotDOMHtmlUtilService.getButtomHTML(this.dragLabel, 'dotedit-contentlet__drag', dataset)}
-            ${this.dotDOMHtmlUtilService.getButtomHTML(this.editLabel, editButtonClass, {
-                ...dataset,
-                'dot-object': 'edit-content'
-            })}
-            ${this.dotDOMHtmlUtilService.getButtomHTML(this.removeLabel, 'dotedit-contentlet__remove', {
-                ...dataset,
-                'dot-object': 'remove-content'
-            })}
+            ${this.dotDOMHtmlUtilService.getButtomHTML(
+                this.dotMessageService.get('editpage.content.contentlet.menu.drag'),
+                'dotedit-contentlet__drag',
+                {
+                    ...dataset,
+                    'dot-object': 'drag-content'
+                }
+            )}
+            ${this.dotDOMHtmlUtilService.getButtomHTML(
+                this.dotMessageService.get('editpage.content.contentlet.menu.edit'),
+                editButtonClass,
+                {
+                    ...dataset,
+                    'dot-object': 'edit-content'
+                }
+            )}
+            ${this.dotDOMHtmlUtilService.getButtomHTML(
+                this.dotMessageService.get('editpage.content.contentlet.menu.remove'),
+                'dotedit-contentlet__remove',
+                {
+                    ...dataset,
+                    'dot-object': 'remove-content'
+                }
+            )}
         `;
     }
 

--- a/src/app/portlets/dot-edit-page/content/shared/iframe-edit-mode.css.ts
+++ b/src/app/portlets/dot-edit-page/content/shared/iframe-edit-mode.css.ts
@@ -37,7 +37,7 @@ export const EDIT_PAGE_CSS = `
         background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVQoU2NkIAIEH/r5n5GQOpCitXbsjHgVwhSBDMOpEFkRToXoirAqxKYIQyEuRSgK8SmCKySkCKyQGEUghQCQPycYlScX0wAAAABJRU5ErkJggg==");
     }
 
-    [data-dot-object="edit-content"] {
+    div[data-dot-object="edit-content"] {
         background-image: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjNDQ0NDQ0IiBoZWlnaHQ9IjE4IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4gICAgPHBhdGggZD0iTTMgMTcuMjVWMjFoMy43NUwxNy44MSA5Ljk0bC0zLjc1LTMuNzVMMyAxNy4yNXpNMjAuNzEgNy4wNGMuMzktLjM5LjM5LTEuMDIgMC0xLjQxbC0yLjM0LTIuMzRjLS4zOS0uMzktMS4wMi0uMzktMS40MSAwbC0xLjgzIDEuODMgMy43NSAzLjc1IDEuODMtMS44M3oiLz4gICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPjwvc3ZnPg==);
         background-position: center;
         background-repeat: no-repeat;
@@ -50,7 +50,7 @@ export const EDIT_PAGE_CSS = `
         width: 32px;
     }
 
-    [data-dot-object="edit-content"]:hover {
+    div[data-dot-object="edit-content"]:hover {
         background-color: rgba(68, 68, 68, 0.1);
         opacity: 1;
     }

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.spec.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.spec.ts
@@ -7,7 +7,7 @@ import { DotRenderedPageState } from '../../shared/models/dot-rendered-page-stat
 import { MockDotMessageService } from '../../../../test/dot-message-service.mock';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TooltipModule } from 'primeng/primeng';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture } from '@angular/core/testing';
 import { DOTTestBed } from '../../../../test/dot-test-bed';
 import { mockDotRenderedPage } from './../../../../test/dot-rendered-page.mock';
 import { mockUser } from './../../../../test/login-service.mock';
@@ -160,8 +160,6 @@ describe('DotEditPageNavComponent', () => {
 
             const menuListItems = fixture.debugElement.queryAll(By.css('.edit-page-nav__item'));
             expect(menuListItems[1].nativeElement.classList).toContain('edit-page-nav__item--disabled');
-
-            const layoutTooltipHTML = menuListItems[1].nativeElement.outerHTML;
             expect(menuListItems[1].nativeElement.getAttribute('ng-reflect-text')).toBe('Can’t edit advanced template');
         });
 
@@ -176,7 +174,6 @@ describe('DotEditPageNavComponent', () => {
             const menuListItems = fixture.debugElement.queryAll(By.css('.edit-page-nav__item'));
             expect(menuListItems[1].nativeElement.classList).toContain('edit-page-nav__item--disabled');
 
-            const layoutTooltipHTML = menuListItems[1].nativeElement.outerHTML;
             expect(menuListItems[1].nativeElement.getAttribute('ng-reflect-text')).toBe('Enterprise only');
         });
 

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.ts
@@ -97,10 +97,6 @@ export class DotEditPageNavComponent implements OnChanges {
         };
     }
 
-    private getTemplateItemIcon(template: DotTemplate): string {
-        return !template ? 'fa fa-th-large' : template.drawed ? 'fa fa-th-large' : 'fa fa-code';
-    }
-
     private getTemplateItemLabel(template: DotTemplate): string {
         return this.dotMessageService.get(!template ? 'editpage.toolbar.nav.layout' : 'editpage.toolbar.nav.layout');
     }

--- a/src/app/view/components/_common/iframe/iframe-component/iframe.component.ts
+++ b/src/app/view/components/_common/iframe/iframe-component/iframe.component.ts
@@ -9,7 +9,6 @@ import {
     NgZone
 } from '@angular/core';
 import { LoginService, LoggerService } from 'dotcms-js/dotcms-js';
-import { Observable } from 'rxjs/Observable';
 import { DotLoadingIndicatorService } from '../dot-loading-indicator/dot-loading-indicator.service';
 import { IframeOverlayService } from '../service/iframe-overlay.service';
 import { DotIframeService } from '../service/dot-iframe/dot-iframe.service';
@@ -31,7 +30,6 @@ export class IframeComponent implements OnInit {
 
     constructor(
         private dotIframeService: DotIframeService,
-        private element: ElementRef,
         private loggerService: LoggerService,
         private loginService: LoginService,
         private ngZone: NgZone,

--- a/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.spec.ts
+++ b/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.spec.ts
@@ -1,6 +1,6 @@
 import { ActivatedRoute } from '@angular/router';
 import { By } from '@angular/platform-browser';
-import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, async } from '@angular/core/testing';
 import { DOTTestBed } from '../../../../../test/dot-test-bed';
 import { DebugElement } from '@angular/core';
 import { DotContentletService } from '../../../../../api/services/dot-contentlet.service';
@@ -10,7 +10,6 @@ import { IframePortletLegacyComponent } from './iframe-porlet-legacy.component';
 import { Observable } from 'rxjs/Observable';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SocketFactory, SiteService, LoginService } from 'dotcms-js/dotcms-js';
-import { IframeComponent } from '../iframe-component';
 import { DotLoadingIndicatorService } from '../dot-loading-indicator/dot-loading-indicator.service';
 import { DotRouterService } from '../../../../../api/services/dot-router/dot-router.service';
 import { DotIframeEventsHandler } from './services/iframe-events-handler.service';

--- a/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
+++ b/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, UrlSegment } from '@angular/router';
 
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Observable } from 'rxjs/Observable';
 
 import { SiteService, DotcmsEventsService, LoggerService } from 'dotcms-js/dotcms-js';
 

--- a/src/app/view/components/dot-device-selector/dot-device-selector.component.ts
+++ b/src/app/view/components/dot-device-selector/dot-device-selector.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { DotDevicesService } from '../../../api/services/dot-devices/dot-devices.service';
 import { DotDevice } from '../../../shared/models/dot-device/dot-device.model';
-import { Observable } from 'rxjs/Observable';
 import { DotMessageService } from '../../../api/services/dot-messages-service';
 import { map } from 'rxjs/operators/map';
 import { StringPixels } from '../../../api/util/string-pixels-util';

--- a/src/app/view/components/dot-iframe-dialog/dot-iframe-dialog.component.ts
+++ b/src/app/view/components/dot-iframe-dialog/dot-iframe-dialog.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, SimpleChanges, OnChanges, EventEmitter, Output } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
 
 @Component({
     selector: 'dot-iframe-dialog',

--- a/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
+++ b/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
@@ -7,7 +7,6 @@ import { DOTTestBed } from '../../../test/dot-test-bed';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { mockDotLanguage } from '../../../test/dot-language.mock';
-import { Observable } from 'rxjs/Observable';
 import { StringPixels } from '../../../api/util/string-pixels-util';
 import { DotLanguage } from '../../../shared/models/dot-language/dot-language.model';
 

--- a/src/app/view/components/dot-language-selector/dot-language-selector.component.ts
+++ b/src/app/view/components/dot-language-selector/dot-language-selector.component.ts
@@ -1,9 +1,8 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { DotLanguagesService } from '../../../api/services/dot-languages/dot-languages.service';
 import { DotLanguage } from '../../../shared/models/dot-language/dot-language.model';
-import { Observable } from 'rxjs/Observable';
 import { StringPixels } from '../../../api/util/string-pixels-util';
-import { tap, take } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 @Component({
     selector: 'dot-language-selector',

--- a/src/app/view/components/dot-persona-selector/dot-persona-selector.component.ts
+++ b/src/app/view/components/dot-persona-selector/dot-persona-selector.component.ts
@@ -1,8 +1,6 @@
-import * as _ from 'lodash';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { DotPersonasService } from '../../../api/services/dot-personas/dot-personas.service';
 import { DotPersona } from '../../../shared/models/dot-persona/dot-persona.model';
-import { Observable } from 'rxjs/Observable';
 import { DotMessageService } from '../../../api/services/dot-messages-service';
 import { map, tap, take } from 'rxjs/operators';
 import { StringPixels } from '../../../api/util/string-pixels-util';

--- a/src/app/view/components/main-legacy/main-legacy.component.spec.ts
+++ b/src/app/view/components/main-legacy/main-legacy.component.spec.ts
@@ -3,8 +3,6 @@ import { DOTTestBed } from '../../../test/dot-test-bed';
 import { DebugElement, Component, EventEmitter, Output, Input } from '@angular/core';
 import { MainComponentLegacyComponent } from './main-legacy.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { DotEventsService } from '../../../api/services/dot-events/dot-events.service';
-import { DotDialogService } from '../../../api/services/dot-dialog';
 import { LoginService } from 'dotcms-js/dotcms-js';
 import { LoginServiceMock } from '../../../test/login-service.mock';
 import { By } from '@angular/platform-browser';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         // Can enable this because rules but we need to
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
+        // "noUnusedLocals": true,
+        // "noUnusedParameters": true,
         "target": "es5",
         "typeRoots": [
             "node_modules/@types"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         // Can enable this because rules but we need to
-        // "noUnusedLocals": true,
-        // "noUnusedParameters": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "target": "es5",
         "typeRoots": [
             "node_modules/@types"


### PR DESCRIPTION
1. Update contentlet after `vtl` file code is updated
2. Fix double bind `Document` click event when user navigate with the internal links
3. Fix `vtl` menu not being shown after something in the contentlet or container was updated
4. Fix `content-types-layout.component.spec.ts` test I broke in another issue
5. Fix all the injected buttons binding, now we don't have to rebind every time the HTML change, is all takin care in a global `Document` click handler.
6. Clean up