### PR TITLE
dotCMS/core#16974 Update edit page controllers lang and device 

### DIFF
--- a/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.html
+++ b/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.html
@@ -2,7 +2,7 @@
     secondary
     [(ngModel)]="mode"
     (onChange)="stateSelectorHandler($event.value)"
-    [options]="options$ | async"
+    [options]="options"
 ></p-selectButton>
 <p-inputSwitch
     #locker

--- a/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.scss
+++ b/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.scss
@@ -45,7 +45,7 @@ p-inputSwitch {
         }
 
         .ui-state-disabled .ui-inputswitch-slider:after {
-            color: rgba($black, 0.2);
+            color: $white;
         }
     }
 

--- a/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
+++ b/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, ViewChild, OnChanges, SimpleChanges } from '@angular/core';
 
-import { tap, map, take, switchMap } from 'rxjs/operators';
+import { take, switchMap } from 'rxjs/operators';
 import { Observable, of, from } from 'rxjs';
 
 import { SelectItem } from 'primeng/primeng';
@@ -31,9 +31,9 @@ export class DotEditPageStateControllerComponent implements OnInit, OnChanges {
     lock: boolean;
     lockWarn = false;
     mode: DotPageMode;
-    options$: Observable<SelectItem[]>;
+    options: SelectItem[] = [];
 
-    private messages: { [key: string]: string } = {};
+    private messages: { [key: string]: string };
 
     constructor(
         private dotAlertConfirmService: DotAlertConfirmService,
@@ -42,34 +42,38 @@ export class DotEditPageStateControllerComponent implements OnInit, OnChanges {
         private dotPersonalizeService: DotPersonalizeService
     ) {}
 
-    ngOnInit() {
-        this.options$ = this.dotMessageService
-            .getMessages([
-                'editpage.toolbar.edit.page',
-                'editpage.toolbar.live.page',
-                'editpage.toolbar.preview.page',
-                'editpage.content.steal.lock.confirmation.message.header',
-                'editpage.content.steal.lock.confirmation.message',
-                'editpage.personalization.confirm.message',
-                'editpage.personalization.confirm.header',
-                'editpage.personalization.confirm.with.lock'
-            ])
-            .pipe(
-                tap((messages: { [key: string]: string }) => {
-                    this.messages = messages;
-                }),
-                map(() => this.getStateModeOptions(this.pageState))
-            );
-    }
+    ngOnInit() {}
 
     ngOnChanges(changes: SimpleChanges) {
         const pageState = changes.pageState.currentValue;
+
+        if (this.messages) {
+            this.options = this.getStateModeOptions(pageState);
+        } else {
+            this.dotMessageService
+                .getMessages([
+                    'editpage.toolbar.edit.page',
+                    'editpage.toolbar.live.page',
+                    'editpage.toolbar.preview.page',
+                    'editpage.content.steal.lock.confirmation.message.header',
+                    'editpage.content.steal.lock.confirmation.message',
+                    'editpage.personalization.confirm.message',
+                    'editpage.personalization.confirm.header',
+                    'editpage.personalization.confirm.with.lock'
+                ])
+                .pipe(take(1))
+                .subscribe((messages: { [key: string]: string }) => {
+                    this.messages = messages;
+                    this.options = this.getStateModeOptions(pageState);
+                });
+        }
+
         /*
             When the page is lock but the page is being load from an user that can lock the page
             we want to show the lock off so the new user can steal the lock
         */
-        this.lock = pageState.state.locked && !this.canTakeLock(pageState);
-        this.lockWarn = pageState.page.canLock && pageState.state.lockedByAnotherUser;
+        this.lock = this.isLocked(pageState);
+        this.lockWarn = this.shouldWarnLock(pageState);
         this.mode = pageState.state.mode;
     }
 
@@ -172,6 +176,10 @@ export class DotEditPageStateControllerComponent implements OnInit, OnChanges {
         );
     }
 
+    private isLocked(pageState: DotRenderedPageState): boolean {
+        return pageState.state.locked && !this.canTakeLock(pageState);
+    }
+
     private isPersonalized(): boolean {
         return this.pageState.viewAs.persona && this.pageState.viewAs.persona.personalized;
     }
@@ -201,6 +209,10 @@ export class DotEditPageStateControllerComponent implements OnInit, OnChanges {
         return (
             mode === DotPageMode.EDIT && (this.shouldAskToLock() || this.shouldAskPersonalization())
         );
+    }
+
+    private shouldWarnLock(pageState: DotRenderedPageState): boolean {
+        return pageState.page.canLock && pageState.state.lockedByAnotherUser;
     }
 
     private showConfirmation(): Observable<DotConfirmationType> {

--- a/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.module.ts
+++ b/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.module.ts
@@ -5,11 +5,7 @@ import { DropdownModule } from 'primeng/primeng';
 import { FormsModule } from '@angular/forms';
 import { DotLanguageSelectorModule } from '@components/dot-language-selector/dot-language-selector.module';
 import { DotDeviceSelectorModule } from '@components/dot-device-selector/dot-device-selector.module';
-import { DotPersonasService } from '@services/dot-personas/dot-personas.service';
-import { DotLanguagesService } from '@services/dot-languages/dot-languages.service';
-import { DotDevicesService } from '@services/dot-devices/dot-devices.service';
 import { DotPersonaSelectorModule } from '@components/dot-persona-selector/dot-persona.selector.module';
-import { DotPersonalizeService } from '@services/dot-personalize/dot-personalize.service';
 
 
 @NgModule({
@@ -21,7 +17,6 @@ import { DotPersonalizeService } from '@services/dot-personalize/dot-personalize
         DotLanguageSelectorModule,
         DotDeviceSelectorModule
     ],
-    providers: [DotDevicesService, DotLanguagesService, DotPersonasService, DotPersonalizeService],
     declarations: [DotEditPageViewAsControllerComponent],
     exports: [DotEditPageViewAsControllerComponent]
 })

--- a/src/app/test/dot-languages-service.mock.ts
+++ b/src/app/test/dot-languages-service.mock.ts
@@ -1,9 +1,9 @@
-import { of as observableOf, Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 import { DotLanguage } from '@models/dot-language/dot-language.model';
 import { mockDotLanguage } from './dot-language.mock';
 
 export class DotLanguagesServiceMock {
     get(): Observable<DotLanguage[]> {
-        return observableOf([mockDotLanguage]);
+        return of([mockDotLanguage]);
     }
 }

--- a/src/app/view/components/dot-device-selector/dot-device-selector.component.html
+++ b/src/app/view/components/dot-device-selector/dot-device-selector.component.html
@@ -5,7 +5,7 @@
     <p-dropdown
         (onChange)="change($event.value)"
         [(ngModel)]="value"
-        [disabled]="!options || options.length === 1"
+        [disabled]="disabled"
         [options]="options"
         [style]="{ width: '120px' }"
         dataKey="inode"

--- a/src/app/view/components/dot-device-selector/dot-device-selector.component.scss
+++ b/src/app/view/components/dot-device-selector/dot-device-selector.component.scss
@@ -11,6 +11,13 @@
             box-shadow: none;
         }
     }
+
+    &.disabled {
+        &::ng-deep dot-icon i,
+        label {
+            color: $field-disabled-color;
+        }
+    }
 }
 
 dot-icon {

--- a/src/app/view/components/dot-device-selector/dot-device-selector.component.spec.ts
+++ b/src/app/view/components/dot-device-selector/dot-device-selector.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture } from '@angular/core/testing';
 
 import { DotDeviceSelectorComponent } from './dot-device-selector.component';
-import { DebugElement } from '@angular/core';
+import { DebugElement, Component } from '@angular/core';
 import { DOTTestBed } from '../../../test/dot-test-bed';
 import { DotDevicesService } from '@services/dot-devices/dot-devices.service';
 import { DotDevicesServiceMock } from '../../../test/dot-device-service.mock';
@@ -15,11 +15,25 @@ import { Dropdown } from 'primeng/primeng';
 import { of } from 'rxjs/internal/observable/of';
 import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
 
+@Component({
+    selector: 'dot-test-host-component',
+    template: `
+        <dot-device-selector [value]="value"></dot-device-selector>
+    `
+})
+class TestHostComponent {
+    value: DotDevice = mockDotDevices[0];
+}
+
 describe('DotDeviceSelectorComponent', () => {
+    let fixtureHost: ComponentFixture<TestHostComponent>;
+    let componentHost: TestHostComponent;
+    let deHost: DebugElement;
     let dotDeviceService;
     let component: DotDeviceSelectorComponent;
-    let fixture: ComponentFixture<DotDeviceSelectorComponent>;
+    // let fixture: ComponentFixture<DotDeviceSelectorComponent>;
     let de: DebugElement;
+
     const defaultDevice: DotDevice = {
         name: 'Desktop',
         cssHeight: '',
@@ -33,7 +47,7 @@ describe('DotDeviceSelectorComponent', () => {
 
     beforeEach(() => {
         const testbed = DOTTestBed.configureTestingModule({
-            declarations: [DotDeviceSelectorComponent],
+            declarations: [TestHostComponent, DotDeviceSelectorComponent],
             imports: [BrowserAnimationsModule, DotIconModule],
             providers: [
                 {
@@ -47,22 +61,24 @@ describe('DotDeviceSelectorComponent', () => {
             ]
         });
 
-        fixture = DOTTestBed.createComponent(DotDeviceSelectorComponent);
-        component = fixture.componentInstance;
-        de = fixture.debugElement;
+        fixtureHost = DOTTestBed.createComponent(TestHostComponent);
+        deHost = fixtureHost.debugElement;
+        componentHost = fixtureHost.componentInstance;
+        de = deHost.query(By.css('dot-device-selector'));
+        component = de.componentInstance;
 
         dotDeviceService = testbed.get(DotDevicesService);
     });
 
     it('should have icon', () => {
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
         const icon = de.query(By.css('dot-icon'));
         expect(icon.attributes.name).toBe('devices');
         expect(icon.attributes.big).toBeDefined();
     });
 
     it('should have label', () => {
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
         const label = de.query(By.css('label')).nativeElement;
         expect(label.textContent).toBe('Device');
     });
@@ -80,12 +96,12 @@ describe('DotDeviceSelectorComponent', () => {
     });
 
     it('should add Default Device as first position', () => {
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
         expect(component.options[0]).toEqual(defaultDevice);
     });
 
     it('should set devices that have Width & Height bigger than 0', () => {
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
         const devicesMock = mockDotDevices.filter(
             (device: DotDevice) => +device.cssHeight > 0 && +device.cssWidth > 0
         );
@@ -94,18 +110,37 @@ describe('DotDeviceSelectorComponent', () => {
         expect(component.options[1]).toEqual(devicesMock[0]);
     });
 
-    it('shoudl set fixed width to dropdown', () => {
-        fixture.detectChanges();
+    it('should set fixed width to dropdown', () => {
+        fixtureHost.detectChanges();
         const pDropDown: Dropdown = de.query(By.css('p-dropdown')).componentInstance;
         expect(pDropDown.style).toEqual({ width: '120px' });
     });
 
-    it('should disabled when just hava the default device', () => {
-        spyOn(dotDeviceService, 'get').and.returnValue(of([]));
+    it('should reload options when value change', () => {
+        spyOn(dotDeviceService, 'get').and.callThrough();
 
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
+        componentHost.value = {
+            ...mockDotDevices[1]
+        };
+        fixtureHost.detectChanges();
 
-        const pDropDown: DebugElement = de.query(By.css('p-dropdown'));
-        expect(pDropDown.componentInstance.disabled).toBeTruthy();
+        expect(dotDeviceService.get).toHaveBeenCalledTimes(2);
+    });
+
+    describe('disabled', () => {
+        it('should disabled dropdown when just have just one device', () => {
+            spyOn(dotDeviceService, 'get').and.returnValue(of([]));
+            fixtureHost.detectChanges();
+
+            const pDropDown: DebugElement = de.query(By.css('p-dropdown'));
+            expect(pDropDown.componentInstance.disabled).toBe(true);
+        });
+
+        it('should add class to the host when disabled', () => {
+            spyOn(dotDeviceService, 'get').and.returnValue(of([]));
+            fixtureHost.detectChanges();
+            expect(de.nativeElement.classList.contains('disabled')).toBe(true);
+        });
     });
 });

--- a/src/app/view/components/dot-device-selector/dot-device-selector.module.ts
+++ b/src/app/view/components/dot-device-selector/dot-device-selector.module.ts
@@ -4,10 +4,12 @@ import { DropdownModule } from 'primeng/primeng';
 import { FormsModule } from '@angular/forms';
 import { DotDeviceSelectorComponent } from './dot-device-selector.component';
 import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
+import { DotDevicesService } from '@services/dot-devices/dot-devices.service';
 
 @NgModule({
     imports: [CommonModule, DropdownModule, FormsModule, DotIconModule],
     declarations: [DotDeviceSelectorComponent],
-    exports: [DotDeviceSelectorComponent]
+    exports: [DotDeviceSelectorComponent],
+    providers: [DotDevicesService]
 })
 export class DotDeviceSelectorModule {}

--- a/src/app/view/components/dot-language-selector/dot-language-selector.component.html
+++ b/src/app/view/components/dot-language-selector/dot-language-selector.component.html
@@ -5,7 +5,8 @@
     <p-dropdown
         (onChange)="change($event.value)"
         [(ngModel)]="value"
-        [options]="languagesOptions"
+        [disabled]="disabled"
+        [options]="options"
         [style]="{ width: '120px' }"
         dataKey="id"
         optionLabel="language"

--- a/src/app/view/components/dot-language-selector/dot-language-selector.component.scss
+++ b/src/app/view/components/dot-language-selector/dot-language-selector.component.scss
@@ -12,6 +12,13 @@
             box-shadow: none;
         }
     }
+
+    &.disabled {
+        &::ng-deep dot-icon i,
+        label {
+            color: $field-disabled-color;
+        }
+    }
 }
 
 dot-icon {

--- a/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
+++ b/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
@@ -29,7 +29,7 @@ class TestHostComponent {
     contentInode = '123';
 }
 
-fdescribe('DotLanguageSelectorComponent', () => {
+describe('DotLanguageSelectorComponent', () => {
     let fixtureHost: ComponentFixture<TestHostComponent>;
     // let componentHost: TestHostComponent;
     let deHost: DebugElement;

--- a/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
+++ b/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
@@ -4,26 +4,43 @@ import { DotLanguagesService } from '@services/dot-languages/dot-languages.servi
 import { DotLanguagesServiceMock } from '../../../test/dot-languages-service.mock';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DOTTestBed } from '../../../test/dot-test-bed';
-import { DebugElement } from '@angular/core';
+import { DebugElement, Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { mockDotLanguage } from '../../../test/dot-language.mock';
 import { Dropdown } from 'primeng/primeng';
 import { MockDotMessageService } from '@tests/dot-message-service.mock';
 import { DotMessageService } from '@services/dot-messages-service';
 import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
+import { of } from 'rxjs';
+import { DotLanguage } from '@shared/models/dot-language/dot-language.model';
 
 const messageServiceMock = new MockDotMessageService({
     'editpage.viewas.label.language': 'Language'
 });
 
-describe('DotLanguageSelectorComponent', () => {
+@Component({
+    selector: 'dot-test-host-component',
+    template: `
+        <dot-language-selector [value]="value"></dot-language-selector>
+    `
+})
+class TestHostComponent {
+    value: DotLanguage = mockDotLanguage;
+    contentInode = '123';
+}
+
+fdescribe('DotLanguageSelectorComponent', () => {
+    let fixtureHost: ComponentFixture<TestHostComponent>;
+    // let componentHost: TestHostComponent;
+    let deHost: DebugElement;
+    let dotLanguagesService: DotLanguagesService;
     let component: DotLanguageSelectorComponent;
-    let fixture: ComponentFixture<DotLanguageSelectorComponent>;
+    // let fixture: ComponentFixture<DotLanguageSelectorComponent>;
     let de: DebugElement;
 
     beforeEach(() => {
-        DOTTestBed.configureTestingModule({
-            declarations: [DotLanguageSelectorComponent],
+        const testbed = DOTTestBed.configureTestingModule({
+            declarations: [TestHostComponent, DotLanguageSelectorComponent],
             imports: [BrowserAnimationsModule, DotIconModule],
             providers: [
                 {
@@ -37,31 +54,35 @@ describe('DotLanguageSelectorComponent', () => {
             ]
         });
 
-        fixture = DOTTestBed.createComponent(DotLanguageSelectorComponent);
-        component = fixture.componentInstance;
-        de = fixture.debugElement;
+        fixtureHost = DOTTestBed.createComponent(TestHostComponent);
+        deHost = fixtureHost.debugElement;
+        // componentHost = fixtureHost.componentInstance;
+        de = deHost.query(By.css('dot-language-selector'));
+        component = de.componentInstance;
+
+        dotLanguagesService = testbed.get(DotLanguagesService);
     });
 
     it('should have icon', () => {
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
         const icon = de.query(By.css('dot-icon'));
         expect(icon.attributes.name).toBe('language');
         expect(icon.attributes.big).toBeDefined();
     });
 
     it('should have label', () => {
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
         const label = de.query(By.css('label')).nativeElement;
         expect(label.textContent).toBe('Language');
     });
 
     it('should load languages in the dropdown', () => {
-        fixture.detectChanges();
+        fixtureHost.detectChanges();
         const decoratedLanguage = {
             ...mockDotLanguage,
             language: `${mockDotLanguage.language} (${mockDotLanguage.countryCode})`
         };
-        expect(component.languagesOptions).toEqual([decoratedLanguage]);
+        expect(component.options).toEqual([decoratedLanguage]);
     });
 
     it('should have right attributes on dropdown', () => {
@@ -83,9 +104,27 @@ describe('DotLanguageSelectorComponent', () => {
         expect(component.selected.emit).toHaveBeenCalledWith(mockDotLanguage);
     });
 
-    it('shoudl set fixed width to dropdown', () => {
-        fixture.detectChanges();
+    it('should set fixed width to dropdown', () => {
+        fixtureHost.detectChanges();
         const pDropDown: Dropdown = de.query(By.css('p-dropdown')).componentInstance;
         expect(pDropDown.style).toEqual({ width: '120px' });
+    });
+
+    describe('disabled', () => {
+        it('should set disable when no lang options present', () => {
+            spyOn(dotLanguagesService, 'get').and.returnValue(of([]));
+
+            fixtureHost.detectChanges();
+
+            expect(dotLanguagesService.get).toHaveBeenCalledTimes(1);
+            const pDropDown: DebugElement = de.query(By.css('p-dropdown'));
+            expect(pDropDown.componentInstance.disabled).toBe(true);
+        });
+
+        it('should add class to the host when disabled', () => {
+            spyOn(dotLanguagesService, 'get').and.returnValue(of([]));
+            fixtureHost.detectChanges();
+            expect(de.nativeElement.classList.contains('disabled')).toBe(true);
+        });
     });
 });

--- a/src/app/view/components/dot-language-selector/dot-language-selector.module.ts
+++ b/src/app/view/components/dot-language-selector/dot-language-selector.module.ts
@@ -4,10 +4,12 @@ import { DropdownModule } from 'primeng/primeng';
 import { FormsModule } from '@angular/forms';
 import { DotLanguageSelectorComponent } from './dot-language-selector.component';
 import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
+import { DotLanguagesService } from '@services/dot-languages/dot-languages.service';
 
 @NgModule({
     imports: [CommonModule, DropdownModule, FormsModule, DotIconModule],
     declarations: [DotLanguageSelectorComponent],
-    exports: [DotLanguageSelectorComponent]
+    exports: [DotLanguageSelectorComponent],
+    providers: [DotLanguagesService]
 })
 export class DotLanguageSelectorModule {}

--- a/src/app/view/components/dot-persona-selector/dot-persona.selector.module.ts
+++ b/src/app/view/components/dot-persona-selector/dot-persona.selector.module.ts
@@ -9,6 +9,8 @@ import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
 import { DotAvatarModule } from '@components/_common/dot-avatar/dot-avatar.module';
 import { DotPersonaSelectedItemModule } from '@components/dot-persona-selected-item/dot-persona-selected-item.module';
 import { PaginatorService } from '@services/paginator';
+import { DotPersonasService } from '@services/dot-personas/dot-personas.service';
+import { DotPersonalizeService } from '@services/dot-personalize/dot-personalize.service';
 
 @NgModule({
     declarations: [DotPersonaSelectorComponent],
@@ -24,6 +26,6 @@ import { PaginatorService } from '@services/paginator';
         ButtonModule,
         SharedModule
     ],
-    providers: [PaginatorService]
+    providers: [PaginatorService, DotPersonasService, DotPersonalizeService]
 })
 export class DotPersonaSelectorModule {}

--- a/src/styles/primeng-theme/components/_inputswitch.scss
+++ b/src/styles/primeng-theme/components/_inputswitch.scss
@@ -42,10 +42,11 @@
     }
 
     .ui-state-disabled & {
-        background-color: $inputswitch-normal-track-color;
+        background-color: $inputswitch-disabled-track-color;
+        opacity: 0.3;
 
         &:before {
-            background-color: $inputswitch-normal-track-color;
+            background-color: $inputswitch-disabled-thumb-color;
         }
     }
 }

--- a/src/styles/primeng-theme/utils/_theme-variables.scss
+++ b/src/styles/primeng-theme/utils/_theme-variables.scss
@@ -216,6 +216,9 @@ $inputswitch-warn-normal-track-color: rgba($orange, 0.38);
 $inputswitch-warn-checked-track-color: rgba($orange, 0.38);
 $inputswitch-warn-hecked-thumb-color: $orange;
 
+$inputswitch-disabled-track-color: $gray-light;
+$inputswitch-disabled-thumb-color: $gray;
+
 
 // TOAST
 $toast-padding: $basic-padding * 2;


### PR DESCRIPTION
Language and device controllers needs to update their options when the page state change, also needs to be disabled when there are no options for them or the request failed.