### PR TITLE
dotCMS/core#17198 Add tags field and avatar preview to persona create in edit page

### DIFF
--- a/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.html
+++ b/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.html
@@ -7,6 +7,7 @@
                  [placeholder]="placeholder"
                  (onKeyUp)="checkForTag($event)"
                  (completeMethod)="filterTags($event)"
+                 (keydown.enter)="$event.stopPropagation()"
                  (onSelect)="addItem()"
                  (onUnselect)="removeItem($event)"
                  [disabled]="disabled"

--- a/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.ts
+++ b/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.ts
@@ -62,10 +62,8 @@ export class DotAutocompleteTagsComponent implements OnInit, ControlValueAccesso
      * @memberof DotAutocompleteTagsComponent
      */
     checkForTag(event: KeyboardEvent): void {
-        debugger;
         if (event.key === 'Enter') {
             this.addItemOnEnter(event.currentTarget as HTMLInputElement);
-            event.stopPropagation();
         } else if (event.key === 'Backspace') {
             //  PrimeNG p-autoComplete remove elements on Backspace keydown, we don't want that in our component so we're fixing this here.
             this.recoverDeletedElement();

--- a/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.ts
+++ b/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.ts
@@ -62,8 +62,10 @@ export class DotAutocompleteTagsComponent implements OnInit, ControlValueAccesso
      * @memberof DotAutocompleteTagsComponent
      */
     checkForTag(event: KeyboardEvent): void {
+        debugger;
         if (event.key === 'Enter') {
             this.addItemOnEnter(event.currentTarget as HTMLInputElement);
+            event.stopPropagation();
         } else if (event.key === 'Backspace') {
             //  PrimeNG p-autoComplete remove elements on Backspace keydown, we don't want that in our component so we're fixing this here.
             this.recoverDeletedElement();

--- a/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.spec.ts
+++ b/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.spec.ts
@@ -31,7 +31,7 @@ class TestFieldValidationMessageComponent {
     @Input() message: string;
 }
 
-describe('DotAddPersonaDialogComponent', () => {
+fdescribe('DotAddPersonaDialogComponent', () => {
     let component: DotAddPersonaDialogComponent;
     let fixture: ComponentFixture<DotAddPersonaDialogComponent>;
     let dotDialog: DebugElement;
@@ -130,7 +130,8 @@ describe('DotAddPersonaDialogComponent', () => {
                     name: 'Freddy',
                     hostFolder: 'demo',
                     keyTag: 'freddy',
-                    photo: ''
+                    photo: '',
+                    tags: null
                 });
                 const accept = dialog.query(By.css('.dialog__button-accept'));
                 accept.triggerEventHandler('click', {});
@@ -150,7 +151,7 @@ describe('DotAddPersonaDialogComponent', () => {
                 dialog = de.query(By.css('dot-dialog'));
             });
 
-            it('should create and emit the new persona and close dialog if form is valid', () => {
+            it('should create and emit the new persona, disable accept button and close dialog if form is valid', () => {
                 spyOn(component, 'closeDialog');
                 spyOn(
                     dotWorkflowActionsFireService,
@@ -159,16 +160,19 @@ describe('DotAddPersonaDialogComponent', () => {
 
                 submitForm();
 
+                fixture.detectChanges();
                 expect(
                     dotWorkflowActionsFireService.publishContentletAndWaitForIndex
                 ).toHaveBeenCalledWith('persona', {
                     hostFolder: 'demo',
                     keyTag: 'freddy',
                     name: 'Freddy',
-                    photo: ''
+                    photo: '',
+                    tags: null
                 });
                 expect(component.createdPersona.emit).toHaveBeenCalledWith(mockDotPersona);
                 expect(component.closeDialog).toHaveBeenCalled();
+                expect(component.dialogActions.accept.disabled).toEqual(true);
             });
 
             it('should call dotHttpErrorManagerService if endpoint fails', () => {

--- a/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.spec.ts
+++ b/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.spec.ts
@@ -31,7 +31,7 @@ class TestFieldValidationMessageComponent {
     @Input() message: string;
 }
 
-fdescribe('DotAddPersonaDialogComponent', () => {
+describe('DotAddPersonaDialogComponent', () => {
     let component: DotAddPersonaDialogComponent;
     let fixture: ComponentFixture<DotAddPersonaDialogComponent>;
     let dotDialog: DebugElement;

--- a/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.ts
+++ b/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.ts
@@ -61,7 +61,6 @@ export class DotAddPersonaDialogComponent implements OnInit {
      * @memberof DotAddPersonaDialogComponent
      */
     closeDialog(): void {
-        console.log('closeDialog');
         this.visible = false;
         this.personaForm.resetForm();
         this.dialogActions.accept.disabled = true;
@@ -69,6 +68,7 @@ export class DotAddPersonaDialogComponent implements OnInit {
 
     private savePersona(): void {
         if (this.personaForm.form.valid) {
+            this.dialogActions.accept.disabled = true;
             this.dotWorkflowActionsFireService
                 .publishContentletAndWaitForIndex<DotPersona>(
                     PERSONA_CONTENT_TYPE,

--- a/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.html
+++ b/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.html
@@ -10,7 +10,7 @@
 
     <div class="form__group">
         <label for="persona-name" class="form__label">{{messagesKey['modes.persona.name']}}</label>
-        <input id="persona-name" dotAutofocus type="text" (change)="setKeyTag()" formControlName="name" name="name" pInputText />
+        <input id="persona-name" dotAutofocus type="text" (keyup)="setKeyTag()" formControlName="name" name="name" pInputText />
         <dot-field-validation-message
             [message]="messagesKey['modes.persona.name.error.required']"
             [field]="form.get('name')">

--- a/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.spec.ts
+++ b/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.spec.ts
@@ -136,7 +136,7 @@ describe('DotCreatePersonaFormComponent', () => {
             const nameInput: DebugElement = fixture.debugElement.query(By.css('#persona-name'));
             const keyTagInput: DebugElement = fixture.debugElement.query(By.css('#persona-keyTag'));
             component.form.get('name').setValue('John Doe');
-            nameInput.triggerEventHandler('change', {});
+            nameInput.triggerEventHandler('keyup', {});
             fixture.detectChanges();
             expect(keyTagInput.nativeElement.value).toEqual('johnDoe');
         });


### PR DESCRIPTION
fix to disable multiple click on form submit, and avoid submit on enter on `autocomplete`