### PR TITLE
dotCMS/core#17178 Link content types entries to contentlets results

### DIFF
--- a/src/app/api/services/dot-router/dot-router.service.spec.ts
+++ b/src/app/api/services/dot-router/dot-router.service.spec.ts
@@ -123,6 +123,7 @@ describe('DotRouterService', () => {
     it('should return the correct  Portlet Id', () => {
         expect(service.getPortletId('#/c/content?test=value')).toBe('content');
         expect(service.getPortletId('/c/add/content?fds=ds')).toBe('content');
+        expect(service.getPortletId('c/content%3Ffilter%3DProducts/19d3aecc-5b68-4d98-ba1b-297d5859403c')).toBe('content');
     });
 
 });

--- a/src/app/api/services/dot-router/dot-router.service.ts
+++ b/src/app/api/services/dot-router/dot-router.service.ts
@@ -136,6 +136,7 @@ export class DotRouterService {
     }
 
     getPortletId(url: string): string {
+        url = decodeURIComponent(url);
         if (url.indexOf('?') > 0) {
             url = url.substring(0, url.indexOf('?'));
         }


### PR DESCRIPTION
fix for:  https://github.com/dotCMS/core/issues/17178#issuecomment-537709724 