### PR TITLE
Allow to receive language code or id, when getting a page. 

### DIFF
--- a/projects/dotcms/src/lib/api/DotApiPage.ts
+++ b/projects/dotcms/src/lib/api/DotApiPage.ts
@@ -24,9 +24,9 @@ export class DotApiPage {
         if (params.language) {
             params = {
                 ...params,
-                language: isNaN(params.language as any) ? await this.dotAppLanguage.getId(params.language) : params.language
-                    ? params.language
-                    : await this.dotAppLanguage.getId(params.language)
+                language: isNaN(params.language as any)
+                    ? await this.dotAppLanguage.getId(params.language)
+                    : params.language
             };
         }
 

--- a/projects/dotcms/src/lib/api/DotApiPage.ts
+++ b/projects/dotcms/src/lib/api/DotApiPage.ts
@@ -24,7 +24,9 @@ export class DotApiPage {
         if (params.language) {
             params = {
                 ...params,
-                language: await this.dotAppLanguage.getId(params.language)
+                language: !isNaN(params.language as any)
+                    ? params.language
+                    : await this.dotAppLanguage.getId(params.language)
             };
         }
 

--- a/projects/dotcms/src/lib/api/DotApiPage.ts
+++ b/projects/dotcms/src/lib/api/DotApiPage.ts
@@ -24,7 +24,7 @@ export class DotApiPage {
         if (params.language) {
             params = {
                 ...params,
-                language: !isNaN(params.language as any)
+                language: isNaN(params.language as any) ? await this.dotAppLanguage.getId(params.language) : params.language
                     ? params.language
                     : await this.dotAppLanguage.getId(params.language)
             };


### PR DESCRIPTION
We are assuming that `params.language` is always a code ( `en | es`), but can be cases where can be the language id directly. This fix is to take in consideration the second scenario. 