### PR TITLE
dotCMS/core#18084 Problems with the language drop down in edit mode

### DIFF
--- a/src/app/api/services/dot-page-render/dot-page-render.service.spec.ts
+++ b/src/app/api/services/dot-page-render/dot-page-render.service.spec.ts
@@ -120,7 +120,7 @@ describe('DotPageRenderService', () => {
             );
         });
 
-        it('should get a page with all params', () => {
+        it('should get a page with all params and preserve render options over extraParams', () => {
             service
                 .get({
                     url,
@@ -135,11 +135,11 @@ describe('DotPageRenderService', () => {
                             identifier: '6789'
                         }
                     }
-                })
+                }, {language_id: '1'})
                 .subscribe();
 
             expect(lastConnection[0].request.url).toBe(
-                `v1/page/render/${url}?com.dotmarketing.persona.id=6789&device_inode=1234&language_id=3`
+                `v1/page/render/${url}?language_id=3&com.dotmarketing.persona.id=6789&device_inode=1234`
             );
         });
     });

--- a/src/app/api/services/dot-page-render/dot-page-render.service.ts
+++ b/src/app/api/services/dot-page-render/dot-page-render.service.ts
@@ -31,12 +31,11 @@ export class DotPageRenderService {
         extraParams?: Params
     ): Observable<DotPageRender.Parameters> {
         const params: DotPageRenderRequestParams = this.getOptionalViewAsParams(viewAs, mode);
-
         return this.coreWebService
             .requestView({
                 method: RequestMethod.Get,
                 url: `v1/page/render/${url.replace(/^\//, '')}`,
-                params: { ...params, ...extraParams }
+                params: { ...extraParams, ...params }
             })
             .pipe(pluck('entity'));
     }


### PR DESCRIPTION
preserve render options over extraParams, when requesting a page. 