### PR TITLE
feat: allow custom fetch for dotcms requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
             "dependencies": {
                 "source-map": {
                     "version": "0.5.6",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                    "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                     "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
                     "dev": true
                 },
@@ -4059,6 +4059,29 @@
             "integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ==",
             "dev": true
         },
+        "@types/node-fetch": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.6.tgz",
+            "integrity": "sha512-2w0NTwMWF1d3NJMK0Uiq2UNN8htVCyOWOD0jIPjPgC5Ph/YP4dVhs9YxxcMcuLuwAslz0dVEcZQUaqkLs3IzOQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+                    "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                }
+            }
+        },
         "@types/npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.2.tgz",
@@ -4079,7 +4102,7 @@
         },
         "@types/q": {
             "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+            "resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
             "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
             "dev": true
         },
@@ -4900,7 +4923,7 @@
         },
         "async": {
             "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
@@ -4984,7 +5007,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -5998,7 +6021,7 @@
         },
         "browserify-aes": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
@@ -6035,7 +6058,7 @@
         },
         "browserify-rsa": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
@@ -6255,7 +6278,7 @@
         },
         "camelcase-keys": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
@@ -7474,7 +7497,7 @@
         },
         "create-hash": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
@@ -7487,7 +7510,7 @@
         },
         "create-hmac": {
             "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
@@ -8040,7 +8063,7 @@
         },
         "diffie-hellman": {
             "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
@@ -8393,7 +8416,7 @@
         },
         "engine.io-client": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+            "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
             "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
             "dev": true,
             "requires": {
@@ -8560,7 +8583,7 @@
         },
         "es6-promisify": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "dev": true,
             "requires": {
@@ -10149,7 +10172,7 @@
         },
         "get-stream": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
         },
@@ -10399,7 +10422,7 @@
         },
         "got": {
             "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+            "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "dev": true,
             "requires": {
@@ -10918,7 +10941,7 @@
         },
         "http-proxy-middleware": {
             "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+            "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
             "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "dev": true,
             "requires": {
@@ -11624,7 +11647,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -12177,7 +12200,7 @@
         },
         "jasmine-core": {
             "version": "2.99.1",
-            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
+            "resolved": "http://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
             "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
             "dev": true
         },
@@ -12314,7 +12337,7 @@
         },
         "json5": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
@@ -12644,7 +12667,7 @@
         },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
@@ -13065,7 +13088,7 @@
         },
         "meow": {
             "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
@@ -13450,7 +13473,7 @@
         },
         "mute-stream": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
         },
@@ -13719,7 +13742,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                     "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true
                 }
@@ -17348,7 +17371,7 @@
         },
         "opn": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+            "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
             "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
             "dev": true,
             "requires": {
@@ -17416,7 +17439,7 @@
         },
         "os-locale": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
@@ -18521,7 +18544,7 @@
                 },
                 "globby": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                    "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
                     "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
                     "dev": true,
                     "requires": {
@@ -18601,7 +18624,7 @@
                 },
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 },
@@ -18653,7 +18676,7 @@
                 },
                 "supports-color": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 },
@@ -20011,7 +20034,7 @@
         },
         "sax": {
             "version": "0.5.8",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+            "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
             "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
             "dev": true
         },
@@ -20299,7 +20322,7 @@
         },
         "sha.js": {
             "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
@@ -20615,7 +20638,7 @@
         },
         "socket.io-parser": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
             "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
             "dev": true,
             "requires": {
@@ -21159,7 +21182,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -21591,7 +21614,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -22784,7 +22807,7 @@
                 },
                 "source-map": {
                     "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
@@ -23299,7 +23322,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "@types/googlemaps": "^3.30.1",
         "@types/jasmine": "~2.8.8",
         "@types/jasminewd2": "~2.0.3",
+        "@types/node-fetch": "^2.5.6",
         "babel-loader": "^8.0.6",
         "codelyzer": "~4.5.0",
         "gh-pages": "^2.0.1",

--- a/projects/dotcms/src/lib/api/DotApiAuthorization.ts
+++ b/projects/dotcms/src/lib/api/DotApiAuthorization.ts
@@ -1,5 +1,5 @@
-import fetch from 'node-fetch';
-import { DotCMSAuthorizationLoginParams, DotCMSError } from '../models';
+import nodeFetch from 'node-fetch';
+import { DotCMSAuthorizationLoginParams, DotCMSError, DotCMSConfigurationParams } from '../models';
 
 function getErrorMessage(data: { [key: string]: any }) {
     if (data.errors) {
@@ -16,12 +16,19 @@ function getErrorMessage(data: { [key: string]: any }) {
  *
  */
 export class DotApiAuthorization {
+    private _config: DotCMSConfigurationParams;
+
+    constructor(config: DotCMSConfigurationParams) {
+        this._config = config;
+    }
+
     /**
      * Given user, password and expiration date to get a DotCMS Autorization Token
      */
     getToken(params: DotCMSAuthorizationLoginParams): Promise<Response> {
         const { user, password, expirationDays, host } = params;
 
+        const fetch = this._config.fetch || nodeFetch;
         return fetch(`${host || ''}/api/v1/authentication/api-token`, {
             method: 'POST',
             headers: {
@@ -32,7 +39,7 @@ export class DotApiAuthorization {
                 password: password,
                 expirationDays: expirationDays || 10
             })
-        }).then(async (res: Response) => {
+        }).then(async (res) => {
             const data = await res.json();
 
             if (res.status === 200) {

--- a/projects/dotcms/src/lib/api/DotApiAuthorization.ts
+++ b/projects/dotcms/src/lib/api/DotApiAuthorization.ts
@@ -25,7 +25,7 @@ export class DotApiAuthorization {
     /**
      * Given user, password and expiration date to get a DotCMS Autorization Token
      */
-    getToken(params: DotCMSAuthorizationLoginParams): Promise<Response> {
+    getToken(params: DotCMSAuthorizationLoginParams) {
         const { user, password, expirationDays, host } = params;
 
         const fetch = this._config.fetch || nodeFetch;

--- a/projects/dotcms/src/lib/api/DotApiConfiguration.ts
+++ b/projects/dotcms/src/lib/api/DotApiConfiguration.ts
@@ -18,7 +18,7 @@ export class DotApiConfiguration {
             .request({
                 url: '/api/v1/configuration'
             })
-            .then(async (response: Response) => {
+            .then(async (response) => {
                 if (response.status === 200) {
                     const data = await response.json();
                     return data.entity;

--- a/projects/dotcms/src/lib/api/DotApiContent.ts
+++ b/projects/dotcms/src/lib/api/DotApiContent.ts
@@ -35,18 +35,18 @@ export class DotApiContent {
         this.dotCMSHttpClient = httpClient;
     }
 
-    query(params: DotCMSContentQuery): Promise<Response> {
+    query(params: DotCMSContentQuery) {
         const url = `/api/content/query/+contentType:${params.contentType}%20${populateQueryUrl(
             params
         )}`;
         return this.doRequest(url, null, 'GET');
     }
 
-    save<Content extends DotCMSContent>(params: Content): Promise<Response> {
+    save<Content extends DotCMSContent>(params: Content) {
         return this.doRequest('/api/content/save/1', params);
     }
 
-    publish<Content extends DotCMSContent>(params: Content): Promise<Response> {
+    publish<Content extends DotCMSContent>(params: Content) {
         return this.doRequest('/api/content/publish/1', params);
     }
 
@@ -54,7 +54,7 @@ export class DotApiContent {
         url: string,
         params?: Content,
         httpMethod = 'POST'
-    ): Promise<Response> {
+    ) {
         const response = await this.dotCMSHttpClient.request({
             url,
             method: httpMethod,

--- a/projects/dotcms/src/lib/api/DotApiPage.ts
+++ b/projects/dotcms/src/lib/api/DotApiPage.ts
@@ -38,7 +38,7 @@ export class DotApiPage {
             url: `/api/v1/page/${format}${params.url}`
         };
 
-        return this.dotCMSHttpClient.request(params).then(async (res: Response) => {
+        return this.dotCMSHttpClient.request(params).then(async (res) => {
             if (res.status === 200) {
                 const data = await res.json();
                 return <DotCMSPageAsset>data.entity;

--- a/projects/dotcms/src/lib/api/DotApiWidget.ts
+++ b/projects/dotcms/src/lib/api/DotApiWidget.ts
@@ -20,7 +20,7 @@ export class DotApiWidget {
             .request({
                 url: `/api/widget/id/${widgetId}`
             })
-            .then(async (response: Response) => {
+            .then(async (response) => {
                 if (response.status === 200) {
                     return response.text();
                 }

--- a/projects/dotcms/src/lib/models/DotCMSConfiguration.model.ts
+++ b/projects/dotcms/src/lib/models/DotCMSConfiguration.model.ts
@@ -1,8 +1,10 @@
+import fetch from 'node-fetch';
 import { DotCMSLanguageItem } from './';
 
 export interface DotCMSConfigurationParams {
     token: string;
     host?: string;
+    fetch?: typeof fetch;
 }
 
 export interface DotCMSConfigurationItem {

--- a/projects/dotcms/src/lib/utils/DotCMSHttpClient.ts
+++ b/projects/dotcms/src/lib/utils/DotCMSHttpClient.ts
@@ -8,7 +8,7 @@ export class DotCMSHttpClient {
         this._config = config;
     }
 
-    public request(params: DotAppHttpRequestParams): Promise<any> {
+    public request(params: DotAppHttpRequestParams) {
         return request(params, this._config);
     }
 }

--- a/projects/dotcms/src/lib/utils/request.ts
+++ b/projects/dotcms/src/lib/utils/request.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import { DotCMSConfigurationParams, DotAppHttpRequestParams } from '../models';
 
 async function getLangQueryParam(language: string): Promise<string> {
@@ -42,5 +42,6 @@ function getOpts(
 export async function request(params: DotAppHttpRequestParams, config: DotCMSConfigurationParams) {
     const url = await getUrl(params, config);
     const opts = getOpts(params, config);
+    const fetch = config.fetch || nodeFetch;
     return fetch(url, opts);
 }

--- a/projects/dotcms/src/lib/utils/tests/DotCMSHttpClient.spec.ts
+++ b/projects/dotcms/src/lib/utils/tests/DotCMSHttpClient.spec.ts
@@ -1,0 +1,17 @@
+import { DotCMSHttpClient } from '../../utils/DotCMSHttpClient';
+
+describe('DotCMSHttpClient', () => {
+    it('should make request with a custom fetch implementation', async () => {
+        const fetchObj = { mock: () => {} };
+        spyOn(fetchObj, 'mock');
+
+        const httpClient = new DotCMSHttpClient({
+            token: '',
+            host: 'http://localhost',
+            fetch: fetchObj.mock as any
+        });
+
+        await httpClient.request({ url: '/test' });
+        expect(fetchObj.mock).toHaveBeenCalled();
+    });
+});

--- a/projects/dotcms/src/public_api.ts
+++ b/projects/dotcms/src/public_api.ts
@@ -37,7 +37,7 @@ export const initDotCMS = (config: DotCMSConfigurationParams): DotCMSApp => {
     const dotApiContentType = new DotApiContentType(httpClient);
 
     return {
-        auth: new DotApiAuthorization(),
+        auth: new DotApiAuthorization(config),
         config: apiConfig,
         content: content,
         contentType: new DotApiContentType(httpClient),


### PR DESCRIPTION
These changes add support for using a custom fetch implementation and adds `node-fetch` types.

The use case I have is that our dotCMS instance is hosted behind a load balancer. Each request to the dotCMS API will switch nodes round-robin unless cookies are stored between requests. I'd like to use [`fetch-cookie`](https://www.npmjs.com/package/fetch-cookie) with `node-fetch` to store cookies, thus sticking with one node instead of alternating between requests.

Usage:
```ts
const dotCmsApi = initDotCMS({
  host: process.env.DOTCMS_HOST,
  token: process.env.DOTCMS_TOKEN,
  fetch: customFetch
})
```