### PR TITLE
dotCMS/core#18716 5.3.2 Main nav does not scoll

### DIFF
--- a/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
+++ b/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
@@ -1,6 +1,7 @@
 <div class="dot-nav__title">
     <div
         (click)="clickHandler($event, data)"
+        (mouseenter)="setSubMenuPosition()"
         [class.dot-nav__item--active]="data.active"
         appendTo="target"
         class="dot-nav__item"
@@ -15,5 +16,11 @@
         </dot-icon>
     </div>
 </div>
-<dot-sub-nav [data]="data" [collapsed]="collapsed" (itemClick)="handleItemClick($event)">
+<dot-sub-nav
+    #subnav
+    [ngStyle]="customStyles"
+    [data]="data"
+    [collapsed]="collapsed"
+    (itemClick)="handleItemClick($event)"
+>
 </dot-sub-nav>

--- a/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
+++ b/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
@@ -13,20 +13,17 @@ import { dotMenuMock } from '../../services/dot-navigation.service.spec';
 import { DotMenu } from '@models/navigation';
 import { TooltipModule } from 'primeng/primeng';
 import { DOTTestBed } from '@tests/dot-test-bed';
-import { BehaviorSubject } from 'rxjs';
 
 @Component({
     selector: 'dot-test-host-component',
-    template: `
-        <dot-nav-item [data]="menu" [collapsed]="collapsed$ | async"></dot-nav-item>
-    `
+    template: ` <dot-nav-item [data]="menu" [collapsed]="collapsed"></dot-nav-item> `
 })
 class TestHostComponent {
     menu: DotMenu = {
         ...dotMenuMock(),
         active: true
     };
-    collapsed$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+    collapsed = false;
 }
 
 describe('DotNavItemComponent', () => {
@@ -38,20 +35,18 @@ describe('DotNavItemComponent', () => {
     let navItem: DebugElement;
     let subNav: DebugElement;
 
-    beforeEach(
-        async(() => {
-            TestBed.configureTestingModule({
-                declarations: [TestHostComponent, DotNavItemComponent, DotSubNavComponent],
-                imports: [
-                    DotNavIconModule,
-                    DotIconModule,
-                    RouterTestingModule,
-                    BrowserAnimationsModule,
-                    TooltipModule
-                ]
-            }).compileComponents();
-        })
-    );
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestHostComponent, DotNavItemComponent, DotSubNavComponent],
+            imports: [
+                DotNavIconModule,
+                DotIconModule,
+                RouterTestingModule,
+                BrowserAnimationsModule,
+                TooltipModule
+            ]
+        }).compileComponents();
+    }));
 
     beforeEach(() => {
         fixtureHost = DOTTestBed.createComponent(TestHostComponent);
@@ -94,6 +89,23 @@ describe('DotNavItemComponent', () => {
     });
 
     describe('dot-sub-nav', () => {
+        it('should set position correctly', () => {
+            deHost.componentInstance.collapsed = true;
+
+            subNav.nativeElement.style.position = 'absolute'
+            subNav.nativeElement.style.top = '5000px' // moving it out of the window
+
+            fixtureHost.detectChanges();
+
+            navItem.triggerEventHandler('mouseenter', {});
+            fixtureHost.detectChanges();
+
+            expect(subNav.styles).toEqual({
+                top: 'auto',
+                bottom: '0'
+            })
+        });
+
         it('should set data correctly', () => {
             expect(subNav.componentInstance.data).toEqual(componentHost.menu);
             expect(subNav.componentInstance.collapsed).toBe(false);
@@ -108,13 +120,12 @@ describe('DotNavItemComponent', () => {
 
     describe('Collapsed', () => {
         beforeEach(() => {
-            componentHost.collapsed$.next(true);
+            componentHost.collapsed = true;
             fixtureHost.detectChanges();
         });
 
         it('should set data correctly on sub-nav', () => {
             expect(subNav.componentInstance.collapsed).toBe(true);
         });
-
     });
 });

--- a/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.ts
+++ b/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.ts
@@ -46,6 +46,7 @@ export class DotNavItemComponent {
      * @memberof DotNavItemComponent
      */
     setSubMenuPosition(): void {
+
         if (this.collapsed) {
             const [rects] = this.subnav.ul.nativeElement.getClientRects();
 

--- a/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.ts
+++ b/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.ts
@@ -1,5 +1,6 @@
-import { Component, Output, EventEmitter, Input, HostBinding } from '@angular/core';
+import { Component, Output, EventEmitter, Input, HostBinding, ViewChild } from '@angular/core';
 import { DotMenu, DotMenuItem } from '@models/navigation';
+import { DotSubNavComponent } from '../dot-sub-nav/dot-sub-nav.component';
 
 @Component({
     selector: 'dot-nav-item',
@@ -7,6 +8,8 @@ import { DotMenu, DotMenuItem } from '@models/navigation';
     styleUrls: ['./dot-nav-item.component.scss']
 })
 export class DotNavItemComponent {
+    @ViewChild('subnav') subnav: DotSubNavComponent;
+
     @Input() data: DotMenu;
 
     @Output()
@@ -18,6 +21,8 @@ export class DotNavItemComponent {
     @HostBinding('class.dot-nav-item__collapsed')
     @Input()
     collapsed: boolean;
+
+    customStyles = {};
 
     constructor() {}
 
@@ -33,6 +38,26 @@ export class DotNavItemComponent {
             originalEvent: $event,
             data: data
         });
+    }
+
+    /**
+     * Align the submenu top or bottom depending of the browser window
+     *
+     * @memberof DotNavItemComponent
+     */
+    setSubMenuPosition(): void {
+        if (this.collapsed) {
+            const [rects] = this.subnav.ul.nativeElement.getClientRects();
+
+            if (rects.bottom > window.innerHeight) {
+                this.customStyles = {
+                    top: 'auto',
+                    bottom: '0'
+                };
+            } else {
+                this.customStyles = {};
+            }
+        }
     }
 
     /**

--- a/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.html
+++ b/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.html
@@ -1,4 +1,4 @@
-<ul class="dot-nav-sub" [class.dot-nav-sub__collapsed]="collapsed">
+<ul #ul class="dot-nav-sub" [class.dot-nav-sub__collapsed]="collapsed">
     <li *ngFor="let subItem of data.menuItems" class="dot-nav-sub__item">
         <a
             class="dot-nav-sub__link"

--- a/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.ts
+++ b/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, Output, EventEmitter, HostBinding } from '@angular/core';
+import {
+    Component,
+    Input,
+    Output,
+    EventEmitter,
+    HostBinding,
+    ElementRef,
+    ViewChild,
+} from '@angular/core';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { DotMenu, DotMenuItem } from '@models/navigation';
 
@@ -27,12 +35,15 @@ import { DotMenu, DotMenuItem } from '@models/navigation';
     styleUrls: ['./dot-sub-nav.component.scss']
 })
 export class DotSubNavComponent {
+    @ViewChild('ul') ul: ElementRef;
+
     @Input() data: DotMenu;
+
     @Output()
     itemClick: EventEmitter<{ originalEvent: MouseEvent; data: DotMenuItem }> = new EventEmitter();
+
     @Input() collapsed: boolean;
 
-    // tslint:disable-next-line: cyclomatic-complexity
     @HostBinding('@expandAnimation') get getAnimation(): string {
         return !this.collapsed && this.data.isOpen ? 'expanded' : 'collapsed';
     }

--- a/src/app/view/components/main-legacy/main-legacy.component.scss
+++ b/src/app/view/components/main-legacy/main-legacy.component.scss
@@ -29,6 +29,7 @@
     background-color: $brand-background;
     flex-shrink: 0;
     transition: width $basic-speed * 2 cubic-bezier(0.25, 0.8, 0.25, 1);
+    overflow-y: scroll;
 
     .collapsed & {
         width: 0;


### PR DESCRIPTION
In the collapsed version what I'm doing is checking the window height and the submenu position and base on that align it the sub menu.

In the expend version is just on line of css.