### PR TITLE
#18714 Fixing error when try to add the same file container twice int…

### DIFF
--- a/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.html
+++ b/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.html
@@ -1,3 +1,3 @@
 <h6>{{ 'editpage.layout.designer.sidebar' | dm }}</h6>
 <dot-sidebar-properties (change)="updateAndPropagate()" [(ngModel)]="value" class="dot-layout-designer__sidebar-properties"></dot-sidebar-properties>
-<dot-container-selector (change)="updateAndPropagate($event)" [data]="containers"></dot-container-selector>
+<dot-container-selector (change)="updateAndPropagate($event)" [data]="containers"  [multiple]="true"></dot-container-selector>

--- a/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.spec.ts
+++ b/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.spec.ts
@@ -31,7 +31,7 @@ class TestHostComponent {
     }
 }
 
-describe('DotEditLayoutSidebarComponent', () => {
+fdescribe('DotEditLayoutSidebarComponent', () => {
     let component: DotEditLayoutSidebarComponent;
     let de: DebugElement;
     let hostComponentfixture: ComponentFixture<TestHostComponent>;
@@ -110,7 +110,7 @@ describe('DotEditLayoutSidebarComponent', () => {
                     uuid: undefined
                 },
                 {
-                    identifier: mockDotContainers[1].container.identifier,
+                    identifier: mockDotContainers[1].container.path,
                     uuid: undefined
                 }
             ],

--- a/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.spec.ts
+++ b/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.spec.ts
@@ -31,7 +31,7 @@ class TestHostComponent {
     }
 }
 
-fdescribe('DotEditLayoutSidebarComponent', () => {
+describe('DotEditLayoutSidebarComponent', () => {
     let component: DotEditLayoutSidebarComponent;
     let de: DebugElement;
     let hostComponentfixture: ComponentFixture<TestHostComponent>;

--- a/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.ts
+++ b/src/app/portlets/dot-edit-page/layout/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.ts
@@ -3,6 +3,7 @@ import { DotLayoutSideBar } from '../../../shared/models/dot-layout-sidebar.mode
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DotContainerColumnBox } from '../../../shared/models/dot-container-column-box.model';
 import { DotEditLayoutService } from '../../../shared/services/dot-edit-layout.service';
+import { TemplateContainersCacheService } from '@portlets/dot-edit-page/template-containers-cache.service';
 
 /**
  * Component in charge of update the model that will be used in the sidebar display containers
@@ -25,7 +26,9 @@ export class DotEditLayoutSidebarComponent implements ControlValueAccessor {
     containers: DotContainerColumnBox[];
     value: DotLayoutSideBar;
 
-    constructor(private dotEditLayoutService: DotEditLayoutService) {}
+    constructor(
+        private dotEditLayoutService: DotEditLayoutService, 
+        private templateContainersCacheService: TemplateContainersCacheService) {}
 
     /**
      * Returns DotContainerColumnBox model.
@@ -38,7 +41,7 @@ export class DotEditLayoutSidebarComponent implements ControlValueAccessor {
         if (containers) {
             this.value.containers = containers.map(item => {
                 return {
-                    identifier: item.container.identifier,
+                    identifier: this.templateContainersCacheService.getContainerReference(item.container),
                     uuid: item.uuid
                 };
             });


### PR DESCRIPTION
When a layout had a sidebar end this sidebar has containers into in, then to the value was taking the id always no matter the containers type

https://github.com/dotCMS/core-web/compare/issue-18714-Container-id-is-being-duplicated?expand=1#diff-2137771d821e30c8a489a7cceb39301eR44

Also we was not allowing add twice the same container into the sidebar

https://github.com/dotCMS/core-web/compare/issue-18714-Container-id-is-being-duplicated?expand=1#diff-fb095d9ba9f6d24e2d155df72d98236fR3