### PR TITLE
Revert "dotCMS/core#18996 Contentlet buttons doesn't show on edit mode with an EMA page (#1402)"

### DIFF
--- a/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
+++ b/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
@@ -84,24 +84,12 @@ export class DotEditContentToolbarHtmlService {
      * @memberof DotEditContentToolbarHtmlService
      */
     addContentletMarkup(doc: Document): void {
-        let counter = 0
-
         const contentletQuery = `[data-dot-object="contentlet"][data-dot-has-page-lang-version="true"]`;
+        const contentlets: HTMLDivElement[] = Array.from(doc.querySelectorAll(contentletQuery));
 
-        const intervalId = setInterval(() => {
-
-            const contentlets: HTMLDivElement[] = Array.from(doc.querySelectorAll(contentletQuery));
-
-            if (contentlets.length || counter === 24) {
-                contentlets.forEach((contentlet: HTMLDivElement) => {
-                    this.addToolbarToContentlet(contentlet);
-                });
-                clearInterval(intervalId);
-            }
-
-            counter++
-        }, 500);
-
+        contentlets.forEach((contentlet: HTMLDivElement) => {
+            this.addToolbarToContentlet(contentlet);
+        });
     }
 
     addToolbarToContentlet(contentlet: HTMLElement) {

--- a/src/app/portlets/dot-edit-page/content/shared/iframe-edit-mode.css.ts
+++ b/src/app/portlets/dot-edit-page/content/shared/iframe-edit-mode.css.ts
@@ -70,6 +70,7 @@ export const getEditPageCss = (timestampId: string): string => {
     }
 
     ${timestampId} [data-dot-object="edit-content"]:hover {
+        background-color: rgba(68, 68, 68, 0.1) !important;
         opacity: 1 !important;
     }
 


### PR DESCRIPTION
This reverts commit 2a104e149317c4b7981f6429ae9b9f2081d49aa9.