### PR TITLE
dotCMS/core#19539 Visitor location dialog in rules too narrow

### DIFF
--- a/projects/dot-rules/src/lib/modal-dialog/dialog-component.ts
+++ b/projects/dot-rules/src/lib/modal-dialog/dialog-component.ts
@@ -5,7 +5,7 @@ import { KeyCode } from '../services/util/key-util';
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: 'cw-modal-dialog',
     template: `<p-dialog
-        width="900"
+        [style]="{width: '900px'}"
         [header]="headerText"
         [visible]="!hidden"
         [modal]="true"


### PR DESCRIPTION
`width` now goes under style property instead of `input` in `p-dialog`