### PR TITLE
dotCMS/core#19727 Template Thumbnail does not load when creating new page.

### DIFF
--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.html
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.html
@@ -1,7 +1,7 @@
 <dot-binary-file
     (dotValueChange)="onThumbnailChange($event)"
     [disabled]="loading"
-    [previewImageUrl]="asset?.assetVersion"
+    [previewImageUrl]="asset?.inode ? '/dA/' + asset?.inode : null"
     [previewImageName]="asset?.name"
     [style.height.rem]="asset ? '7.14' : '3.35'"
     accept="image/*"

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.spec.ts
@@ -103,7 +103,8 @@ describe('DotTemplateThumbnailFieldComponent', () => {
             component.asset = {
                 ...dotcmsContentletMock,
                 assetVersion: 'path/to/something.png',
-                name: 'Something'
+                name: 'Something',
+                inode: '123inode'
             };
 
             fixture.detectChanges();
@@ -113,7 +114,7 @@ describe('DotTemplateThumbnailFieldComponent', () => {
                 jasmine.objectContaining({ accept: 'image/*', style: 'height: 7.14rem;' })
             );
 
-            expect(field.nativeNode.previewImageUrl).toBe('path/to/something.png');
+            expect(field.nativeNode.previewImageUrl).toBe('/dA/123inode');
             expect(field.nativeNode.previewImageName).toBe('Something');
         });
 


### PR DESCRIPTION
set a common url between dotAsset and fileAsset for the Thumbnail. 