### PR TITLE
dotCMS/core#19792 -Correct- We are not updating the portlet title when you are navigating through the backend

### DIFF
--- a/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.spec.ts
+++ b/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.spec.ts
@@ -365,4 +365,35 @@ describe('DotCrumbtrailService', () => {
             }
         ]);
     });
+
+    it('Should get URL segment if resolver data is not available', () => {
+        mockActivatedRoute.root = {
+            firstChild: {
+                data: new BehaviorSubject({}),
+                firstChild: {
+                    data: new BehaviorSubject({}),
+                    firstChild: {
+                        firstChild: {
+                            firstChild: null,
+                            data: new BehaviorSubject({})
+                        },
+                        data: new BehaviorSubject({})
+                    }
+                }
+            }
+        };
+
+        dotNavigationServiceMock.navigationEnd.next({
+            url: 'templates/new',
+            urlAfterRedirects: 'templates/new',
+            id: 1
+        });
+
+        expect(secondCrumb).toEqual([
+            {
+                label: 'new',
+                url: ''
+            }
+        ]);
+    });
 });

--- a/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.ts
+++ b/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.ts
@@ -83,13 +83,15 @@ export class DotCrumbtrailService {
 
     private getCrumbtrailSection(sectionKey: string): string {
         const data: Data = this.getData();
-
         let currentData: any = data;
 
-        this.portletsTitlePathFinder[sectionKey]
-            .split('.')
-            .forEach((key) => (currentData = currentData[key]));
-        return currentData;
+        if (Object.keys(data).length) {
+            this.portletsTitlePathFinder[sectionKey]
+                .split('.')
+                .forEach((key) => (currentData = currentData[key]));
+            return currentData;
+        }
+        return null;
     }
 
     private getData(): Data {
@@ -110,11 +112,11 @@ export class DotCrumbtrailService {
 
         return this.getMenuLabel(portletId).pipe(
             map((crumbTrail: DotCrumb[]) => {
-                if (sections.length > 1 && this.isPortletTitleAvailable(url)) {
+                if (this.shouldAddSection(sections, url)) {
                     const sectionLabel = this.getCrumbtrailSection(sections[0]);
 
                     crumbTrail.push({
-                        label: sectionLabel,
+                        label: sectionLabel ? sectionLabel : sections[1],
                         url: ''
                     });
                 }
@@ -122,6 +124,10 @@ export class DotCrumbtrailService {
                 return crumbTrail;
             })
         );
+    }
+
+    private shouldAddSection(sections: String[], url: string): boolean {
+        return sections.length > 1 && this.isPortletTitleAvailable(url);
     }
 
     private isPortletTitleAvailable(url: string): boolean {


### PR DESCRIPTION
Currently we rely that all routes comes with resolver data, there are some like `template/new `that don't need a resolver.
In those cases we use the url information to add it at the end of the crumb trail.

Example. in `template/new` result in `Site | Templates > new`