### PR TITLE
dotCMS/core#19087 internal QA feedback

### DIFF
--- a/src/app/api/services/dot-router/dot-router.service.ts
+++ b/src/app/api/services/dot-router/dot-router.service.ts
@@ -13,7 +13,11 @@ export class DotRouterService {
     private _previousSavedURL: string;
     private CUSTOM_PORTLET_ID_PREFIX = 'c_';
 
-    constructor(private router: Router, private route: ActivatedRoute) {}
+    constructor(private router: Router, private route: ActivatedRoute) {
+        this.router.routeReuseStrategy.shouldReuseRoute = () => {
+            return false;
+        };
+    }
 
     get currentPortlet(): PortletNav {
         return {

--- a/src/app/api/services/dot-router/dot-router.service.ts
+++ b/src/app/api/services/dot-router/dot-router.service.ts
@@ -13,11 +13,7 @@ export class DotRouterService {
     private _previousSavedURL: string;
     private CUSTOM_PORTLET_ID_PREFIX = 'c_';
 
-    constructor(private router: Router, private route: ActivatedRoute) {
-        this.router.routeReuseStrategy.shouldReuseRoute = () => {
-            return false;
-        };
-    }
+    constructor(private router: Router, private route: ActivatedRoute) {}
 
     get currentPortlet(): PortletNav {
         return {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,4 +1,4 @@
-import { Routes, RouterModule } from '@angular/router';
+import { Routes, RouterModule, RouteReuseStrategy } from '@angular/router';
 import { NgModule } from '@angular/core';
 import { MainCoreLegacyComponent } from '@components/main-core-legacy/main-core-legacy-component';
 import { MainComponentLegacyComponent } from '@components/main-legacy/main-legacy.component';
@@ -13,6 +13,7 @@ import { PublicAuthGuardService } from '@services/guards/public-auth-guard.servi
 import { DotLoginPageComponent } from '@components/login/main/dot-login-page.component';
 import { DotLoginPageResolver } from '@components/login/dot-login-page-resolver.service';
 import { DotIframePortletLegacyResolver } from '@components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service';
+import { DotCustomReuseStrategyService } from '@shared/dot-custom-reuse-strategy/dot-custom-reuse-strategy.service';
 
 const PORTLETS_ANGULAR = [
     {
@@ -179,6 +180,7 @@ const appRoutes: Routes = [
         RouterModule.forRoot(appRoutes, {
             useHash: true
         })
-    ]
+    ],
+    providers: [{ provide: RouteReuseStrategy, useClass: DotCustomReuseStrategyService }]
 })
 export class AppRoutingModule {}

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
@@ -65,7 +65,7 @@ export class DotTemplateCreateEditComponent implements OnInit, OnDestroy {
             data: {
                 template: this.form.value,
                 onSave: (value: DotTemplateItem) => {
-                    this.store.saveTemplate(value);
+                    this.store.saveProperties(value);
                 }
             }
         });

--- a/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
@@ -343,6 +343,45 @@ describe('DotTemplateStore', () => {
                     });
                 });
             });
+            it('should update template and update the state when updates props', () => {
+                service.saveProperties({
+                    body: 'string',
+                    friendlyName: 'string',
+                    identifier: 'string',
+                    title: 'string'
+                });
+
+                expect<any>(dotTemplatesService.update).toHaveBeenCalledWith({
+                    body: 'string',
+                    friendlyName: 'string',
+                    identifier: 'string',
+                    title: 'string'
+                });
+
+                service.state$.subscribe((res) => {
+                    expect(res).toEqual({
+                        working: {
+                            type: 'advanced',
+                            identifier: '222-3000-333---30303-394',
+                            title: 'Updated template',
+                            friendlyName: '',
+                            drawed: false,
+                            body: '<h4>Hi you</h1>',
+                            image: ''
+                        },
+                        original: {
+                            type: 'advanced',
+                            identifier: '222-3000-333---30303-394',
+                            title: 'Updated template',
+                            friendlyName: '',
+                            drawed: false,
+                            body: '<h4>Hi you</h1>',
+                            image: ''
+                        },
+                        apiLink: '/api/v1/templates/2d87af36-a935-4689-b427-dea75e9d84cf/working'
+                    });
+                });
+            });
         });
     });
 });

--- a/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.ts
@@ -109,14 +109,7 @@ export class DotTemplateStore extends ComponentStore<DotTemplateState> {
 
     readonly saveTemplate = this.effect((origin$: Observable<DotTemplateItem>) => {
         return origin$.pipe(
-            switchMap((template: DotTemplateItem) => {
-                delete template.type;
-
-                if (template.type === 'design') {
-                    delete template.containers;
-                }
-                return this.dotTemplateService.update(template as DotTemplate);
-            }),
+            switchMap((template: DotTemplateItem) => this.persistTemplate(template)),
             tap((template: DotTemplate) => {
                 if (template.drawed) {
                     this.templateContainersCacheService.set(template.containers);
@@ -124,6 +117,15 @@ export class DotTemplateStore extends ComponentStore<DotTemplateState> {
 
                 this.updateTemplate(this.getTemplateItem(template));
                 this.goToTemplateList();
+            })
+        );
+    });
+
+    readonly saveProperties = this.effect((origin$: Observable<DotTemplateItem>) => {
+        return origin$.pipe(
+            switchMap((template: DotTemplateItem) => this.persistTemplate(template)),
+            tap((template: DotTemplate) => {
+                this.updateTemplate(this.getTemplateItem(template));
             })
         );
     });
@@ -240,5 +242,13 @@ export class DotTemplateStore extends ComponentStore<DotTemplateState> {
         }
 
         return result;
+    }
+
+    private persistTemplate(template: DotTemplateItem): Observable<DotTemplate> {
+        delete template.type;
+        if (template.type === 'design') {
+            delete template.containers;
+        }
+        return this.dotTemplateService.update(template as DotTemplate);
     }
 }

--- a/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.html
+++ b/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.html
@@ -55,7 +55,6 @@
                 size="14px"
             >
             </dot-state-icon>
-            <dot-icon *ngIf="rowData.locked" name="lock" size="14"></dot-icon>
         </td>
         <td [ngStyle]="{ 'text-align': tableColumns[2].textAlign }">
             {{ rowData.friendlyName }}

--- a/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
@@ -43,7 +43,6 @@ import { DotActionBulkResult } from '@models/dot-action-bulk-result/dot-action-b
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { DotBulkInformationComponent } from '@components/_common/dot-bulk-information/dot-bulk-information.component';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
-import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
 import { DotContentState } from 'dotcms-models';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CoreWebServiceMock } from '@tests/core-web.service.mock';
@@ -278,7 +277,6 @@ describe('DotTemplateListComponent', () => {
                 DotAddToBundleModule,
                 HttpClientTestingModule,
                 DynamicDialogModule,
-                DotIconModule,
                 BrowserAnimationsModule
             ],
             schemas: [CUSTOM_ELEMENTS_SCHEMA]
@@ -349,14 +347,10 @@ describe('DotTemplateListComponent', () => {
             lockedTemplate = fixture.debugElement.query(By.css('[data-testid="123Locked"]'))
                 .componentInstance;
             const stateIcon = fixture.debugElement.query(By.css('dot-state-icon'));
-            const lockIcon = fixture.debugElement.query(
-                By.css('p-table dot-icon[name="lock"][size="14"]')
-            );
 
             expect(stateIcon.attributes['size']).toEqual('14px');
             expect(stateIcon.nativeNode.state).toEqual(state);
             expect(stateIcon.nativeNode.labels).toEqual(labels);
-            expect(lockIcon).toBeDefined();
         });
 
         describe('row', () => {

--- a/src/app/portlets/dot-templates/dot-template-list/dot-template-list.module.ts
+++ b/src/app/portlets/dot-templates/dot-template-list/dot-template-list.module.ts
@@ -14,7 +14,6 @@ import { DotAddToBundleModule } from '@components/_common/dot-add-to-bundle';
 import { DotBulkInformationModule } from '@components/_common/dot-bulk-information/dot-bulk-information.module';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
-import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
 import { DotTemplateSelectorModule } from './components/dot-template-selector/dot-template-selector.module';
 import { DotEmptyStateModule } from '@components/_common/dot-empty-state/dot-empty-state.module';
 
@@ -33,7 +32,6 @@ import { DotEmptyStateModule } from '@components/_common/dot-empty-state/dot-emp
         DotAddToBundleModule,
         DynamicDialogModule,
         DotBulkInformationModule,
-        DotIconModule,
         DotTemplateSelectorModule,
         DotEmptyStateModule
     ],

--- a/src/app/portlets/dot-templates/dot-templates-routing.module.ts
+++ b/src/app/portlets/dot-templates/dot-templates-routing.module.ts
@@ -4,8 +4,6 @@ import { DotTemplateListComponent } from '@portlets/dot-templates/dot-template-l
 import { DotTemplateListResolver } from '@portlets/dot-templates/dot-template-list/dot-template-list-resolver.service';
 import { DotTemplateCreateEditResolver } from './dot-template-create-edit/resolvers/dot-template-create-edit.resolver';
 
-export const EDIT_TEMPLATE_BY_INODE_PATH = 'edit/:id/inode/:inode';
-
 const routes: Routes = [
     {
         path: '',
@@ -32,7 +30,7 @@ const routes: Routes = [
         }
     },
     {
-        path: EDIT_TEMPLATE_BY_INODE_PATH,
+        path: 'edit/:id/inode/:inode',
         loadChildren: () =>
             import(
                 '@portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.module.ts'

--- a/src/app/portlets/dot-templates/dot-templates-routing.module.ts
+++ b/src/app/portlets/dot-templates/dot-templates-routing.module.ts
@@ -4,6 +4,8 @@ import { DotTemplateListComponent } from '@portlets/dot-templates/dot-template-l
 import { DotTemplateListResolver } from '@portlets/dot-templates/dot-template-list/dot-template-list-resolver.service';
 import { DotTemplateCreateEditResolver } from './dot-template-create-edit/resolvers/dot-template-create-edit.resolver';
 
+export const EDIT_TEMPLATE_BY_INODE_PATH = 'edit/:id/inode/:inode';
+
 const routes: Routes = [
     {
         path: '',
@@ -30,11 +32,14 @@ const routes: Routes = [
         }
     },
     {
-        path: 'edit/:id/inode/:inode',
+        path: EDIT_TEMPLATE_BY_INODE_PATH,
         loadChildren: () =>
             import(
                 '@portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.module.ts'
             ).then((m) => m.DotTemplateCreateEditModule),
+        data: {
+            reuseRoute: false
+        },
         resolve: {
             template: DotTemplateCreateEditResolver
         }

--- a/src/app/shared/dot-custom-reuse-strategy/dot-custom-reuse-strategy.service.spec.ts
+++ b/src/app/shared/dot-custom-reuse-strategy/dot-custom-reuse-strategy.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DotCustomReuseStrategyService } from './dot-custom-reuse-strategy.service';
 import { ActivatedRouteSnapshot } from '@angular/router';
 
-fdescribe('DotCustomReuseStrategyService', () => {
+describe('DotCustomReuseStrategyService', () => {
     let service: DotCustomReuseStrategyService;
     const regularRoute = { routeConfig: null, data: {} };
     const regularRoute2 = { routeConfig: { path: 'test' }, data: {} };

--- a/src/app/shared/dot-custom-reuse-strategy/dot-custom-reuse-strategy.service.spec.ts
+++ b/src/app/shared/dot-custom-reuse-strategy/dot-custom-reuse-strategy.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DotCustomReuseStrategyService } from './dot-custom-reuse-strategy.service';
+import { ActivatedRouteSnapshot } from '@angular/router';
+
+fdescribe('DotCustomReuseStrategyService', () => {
+    let service: DotCustomReuseStrategyService;
+    const regularRoute = { routeConfig: null, data: {} };
+    const regularRoute2 = { routeConfig: { path: 'test' }, data: {} };
+    const regularRoute3 = { routeConfig: null, data: {} };
+    const renewRoute = { routeConfig: null, data: { reuseRoute: false } };
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({ providers: [DotCustomReuseStrategyService] });
+        service = TestBed.inject(DotCustomReuseStrategyService);
+    });
+
+    it('should return angular default behavior on retrieve', () => {
+        expect(service.retrieve(regularRoute as ActivatedRouteSnapshot)).toBeNull();
+    });
+
+    it('should return angular default behavior on shouldAttach', () => {
+        expect(service.shouldAttach(regularRoute as ActivatedRouteSnapshot)).toEqual(false);
+    });
+
+    it('should return angular default behavior on shouldDetach', () => {
+        expect(service.shouldDetach(regularRoute as ActivatedRouteSnapshot)).toEqual(false);
+    });
+
+    it('should return true if routeConfig match', () => {
+        expect(
+            service.shouldReuseRoute(
+                regularRoute as ActivatedRouteSnapshot,
+                regularRoute3 as ActivatedRouteSnapshot
+            )
+        ).toEqual(true);
+    });
+
+    it('should return false if routeConfig match but reUseRoute is false', () => {
+        expect(
+            service.shouldReuseRoute(
+                regularRoute as ActivatedRouteSnapshot,
+                (renewRoute as unknown) as ActivatedRouteSnapshot
+            )
+        ).toEqual(true);
+    });
+
+    it('should return false if routeConfig dont match', () => {
+        expect(
+            service.shouldReuseRoute(
+                regularRoute as ActivatedRouteSnapshot,
+                regularRoute2 as ActivatedRouteSnapshot
+            )
+        ).toEqual(false);
+    });
+});

--- a/src/app/shared/dot-custom-reuse-strategy/dot-custom-reuse-strategy.service.ts
+++ b/src/app/shared/dot-custom-reuse-strategy/dot-custom-reuse-strategy.service.ts
@@ -1,0 +1,27 @@
+import { ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy } from '@angular/router';
+
+export class DotCustomReuseStrategyService implements RouteReuseStrategy {
+    constructor() {}
+
+    retrieve(_route: ActivatedRouteSnapshot): DetachedRouteHandle | null {
+        return null;
+    }
+
+    shouldAttach(_route: ActivatedRouteSnapshot): boolean {
+        return false;
+    }
+
+    shouldDetach(_route: ActivatedRouteSnapshot): boolean {
+        return false;
+    }
+
+    shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
+        return future.routeConfig === curr.routeConfig
+            ? future.data.reuseRoute === false
+                ? false
+                : true
+            : false;
+    }
+
+    store(_route: ActivatedRouteSnapshot, _handle: DetachedRouteHandle | null): void {}
+}


### PR DESCRIPTION
- Save template properties should not redirect to listing.
- remove lock icon in template listing. 
- By implementing `dot-custom-reuse-strategy.service.ts`. in a route we can specify if can be reloaded if is in the same route, with `data: { reuseRoute: false }`