### PR TITLE
dotCMS/core#19087 Internal QA feedback

### DIFF
--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
@@ -25,10 +25,11 @@
             </dot-portlet-box>
         </ng-template>
     </p-tabPanel>
-    <p-tabPanel data-testId="historyTab" header="History" [cache]="false">
+    <p-tabPanel header="History">
         <ng-template pTemplate="content">
             <dot-portlet-box>
                 <dot-iframe
+                    #historyIframe
                     (custom)="custom.emit($event)"
                     data-testId="historyIframe"
                     [src]="historyUrl"

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
@@ -25,7 +25,7 @@
             </dot-portlet-box>
         </ng-template>
     </p-tabPanel>
-    <p-tabPanel header="History">
+    <p-tabPanel data-testId="historyTab" header="History" [cache]="false">
         <ng-template pTemplate="content">
             <dot-portlet-box>
                 <dot-iframe

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -205,7 +205,7 @@ describe('DotTemplateBuilderComponent', () => {
             );
         });
 
-        it('should set cahce to false in history tab', () => {
+        it('should set cache to false in history tab', () => {
             const historyTab: TabPanel = de.query(By.css('[data-testId="historyTab"]'))
                 .componentInstance;
             expect(historyTab.cache).toBe(false);

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -17,6 +17,7 @@ import { DotTemplateBuilderComponent } from './dot-template-builder.component';
 import { By } from '@angular/platform-browser';
 import { EMPTY_TEMPLATE_ADVANCED, EMPTY_TEMPLATE_DESIGN } from '../store/dot-template.store';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
+import { TabPanel } from 'primeng/tabview';
 
 @Component({
     selector: 'dot-edit-layout-designer',
@@ -62,6 +63,7 @@ export class TabViewMockComponent {}
 })
 export class TabPanelMockComponent implements AfterContentInit {
     @Input() header: string;
+    @Input() cache = true;
     @ContentChild(TemplateRef) container;
     contentTemplate;
 
@@ -197,10 +199,16 @@ describe('DotTemplateBuilderComponent', () => {
         });
 
         it('should set iframe history url', () => {
-            const permissions = de.query(By.css('[data-testId="historyIframe"]'));
-            expect(permissions.componentInstance.src).toBe(
+            const historyIframe = de.query(By.css('[data-testId="historyIframe"]'));
+            expect(historyIframe.componentInstance.src).toBe(
                 '/html/templates/push_history.jsp?templateId=123&popup=true'
             );
+        });
+
+        it('should set cahce to false in history tab', () => {
+            const historyTab: TabPanel = de.query(By.css('[data-testId="historyTab"]'))
+                .componentInstance;
+            expect(historyTab.cache).toBe(false);
         });
 
         it('should handle custom event', () => {

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
@@ -1,16 +1,26 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+    Component,
+    EventEmitter,
+    Input,
+    OnChanges,
+    OnInit,
+    Output,
+    ViewChild
+} from '@angular/core';
 import { DotTemplateItem } from '../store/dot-template.store';
+import { IframeComponent } from '@components/_common/iframe/iframe-component';
 
 @Component({
     selector: 'dot-template-builder',
     templateUrl: './dot-template-builder.component.html',
     styleUrls: ['./dot-template-builder.component.scss']
 })
-export class DotTemplateBuilderComponent implements OnInit {
+export class DotTemplateBuilderComponent implements OnInit, OnChanges {
     @Input() item: DotTemplateItem;
     @Output() save = new EventEmitter<DotTemplateItem>();
     @Output() cancel = new EventEmitter();
     @Output() custom: EventEmitter<CustomEvent> = new EventEmitter();
+    @ViewChild('historyIframe') historyIframe: IframeComponent;
     permissionsUrl = '';
     historyUrl = '';
 
@@ -19,5 +29,11 @@ export class DotTemplateBuilderComponent implements OnInit {
     ngOnInit() {
         this.permissionsUrl = `/html/templates/permissions.jsp?templateId=${this.item.identifier}&popup=true`;
         this.historyUrl = `/html/templates/push_history.jsp?templateId=${this.item.identifier}&popup=true`;
+    }
+
+    ngOnChanges(): void {
+        if (this.historyIframe) {
+            this.historyIframe.iframeElement.nativeElement.contentWindow.location.reload();
+        }
     }
 }


### PR DESCRIPTION
- Reload History tab if is created (because is lazy-loaded), when a new version of the template is created.  