### PR TITLE
A one-liner fix for the reload issue

### DIFF
--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
@@ -210,6 +210,7 @@ describe('DotEditPageMainComponent', () => {
     });
 
     it('should call goToEditPage if page properties were saved with different URLs', () => {
+        spyOn(dotPageStateService, 'get').and.callThrough();
         editContentlet.custom.emit({
             detail: {
                 name: 'save-page',
@@ -224,6 +225,9 @@ describe('DotEditPageMainComponent', () => {
             url: '/index',
             language_id: '1'
         });
+        dotContentletEditorService.close$.next(true);
+        expect(dotRouterService.goToEditPage).toHaveBeenCalledTimes(1);
+        expect(dotPageStateService.get).not.toHaveBeenCalled();
     });
 
     it('should call get if page properties were saved with equal URLs', () => {

--- a/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
+++ b/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
@@ -78,6 +78,7 @@ export class DotEditPageMainComponent implements OnInit, OnDestroy {
     private subscribeIframeCloseAction(): void {
         this.dotContentletEditorService.close$.pipe(takeUntil(this.destroy$)).subscribe(() => {
             if (this.pageIsSaved) {
+                this.pageIsSaved = false;
                 if (this.pageUrl !== this.route.snapshot.queryParams.url) {
                     this.dotRouterService.goToEditPage({
                         url: this.pageUrl,


### PR DESCRIPTION
As reported by Humberto, the boolean `isPageSaved` was not being reset back to `false`.