### PR TITLE
dotCMS/core#19838 ESC key to close all the dialogs in template portets

### DIFF
--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
@@ -265,8 +265,6 @@ describe('DotTemplateCreateEditComponent', () => {
                 expect(dialogService.open).toHaveBeenCalledWith(jasmine.any(Function), {
                     header: 'Create new template',
                     width: '30rem',
-                    closable: false,
-                    closeOnEscape: false,
                     data: {
                         template: {
                             title: '',
@@ -283,8 +281,7 @@ describe('DotTemplateCreateEditComponent', () => {
                             theme: '',
                             image: ''
                         },
-                        onSave: jasmine.any(Function),
-                        onCancel: jasmine.any(Function)
+                        onSave: jasmine.any(Function)
                     }
                 });
             });
@@ -351,8 +348,6 @@ describe('DotTemplateCreateEditComponent', () => {
                 expect(dialogService.open).toHaveBeenCalledWith(jasmine.any(Function), {
                     header: 'Create new template',
                     width: '30rem',
-                    closable: false,
-                    closeOnEscape: false,
                     data: {
                         template: {
                             title: '',
@@ -361,8 +356,7 @@ describe('DotTemplateCreateEditComponent', () => {
                             friendlyName: '',
                             image: ''
                         },
-                        onSave: jasmine.any(Function),
-                        onCancel: jasmine.any(Function)
+                        onSave: jasmine.any(Function)
                     }
                 });
             });

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
@@ -11,6 +11,7 @@ import { DotTemplate } from '@shared/models/dot-edit-layout-designer/dot-templat
 import { DotTemplatePropsComponent } from './dot-template-props/dot-template-props.component';
 import { DotTemplateItem, DotTemplateState, DotTemplateStore } from './store/dot-template.store';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
+import { DynamicDialogRef } from 'primeng/dynamicdialog/dynamicdialog-ref';
 
 @Component({
     selector: 'dot-template-create-edit',
@@ -114,7 +115,7 @@ export class DotTemplateCreateEditComponent implements OnInit, OnDestroy {
     }
 
     private createTemplate(): void {
-        const ref = this.dialogService.open(DotTemplatePropsComponent, {
+        const ref: DynamicDialogRef = this.dialogService.open(DotTemplatePropsComponent, {
             header: this.dotMessageService.get('templates.create.title'),
             width: '30rem',
             data: {

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
@@ -114,19 +114,19 @@ export class DotTemplateCreateEditComponent implements OnInit, OnDestroy {
     }
 
     private createTemplate(): void {
-        this.dialogService.open(DotTemplatePropsComponent, {
+        const ref = this.dialogService.open(DotTemplatePropsComponent, {
             header: this.dotMessageService.get('templates.create.title'),
             width: '30rem',
-            closable: false,
-            closeOnEscape: false,
             data: {
                 template: this.form.value,
                 onSave: (value: DotTemplateItem) => {
                     this.store.createTemplate(value);
-                },
-                onCancel: () => {
-                    this.store.goToTemplateList();
                 }
+            }
+        });
+        ref.onClose.pipe(takeUntil(this.destroy$)).subscribe((goToListing: boolean) => {
+            if (goToListing || goToListing === undefined) {
+                this.cancelTemplate();
             }
         });
     }

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.spec.ts
@@ -53,8 +53,7 @@ describe('DotTemplateNewComponent', () => {
     it('should open template type selector', () => {
         expect(dialogService.open).toHaveBeenCalledWith(jasmine.any(Function), {
             header: 'Create a template',
-            width: '37rem',
-            closeOnEscape: false
+            width: '37rem'
         });
     });
 

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.ts
@@ -22,8 +22,7 @@ export class DotTemplateNewComponent implements OnInit {
     ngOnInit(): void {
         const ref = this.dialogService.open(DotTemplateSelectorComponent, {
             header: this.dotMessageService.get('templates.select.template.title'),
-            width: '37rem',
-            closeOnEscape: false
+            width: '37rem'
         });
 
         ref.onClose.pipe(take(1)).subscribe((value: string) => {

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.spec.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.spec.ts
@@ -20,14 +20,11 @@ import { By } from '@angular/platform-browser';
     styleUrls: []
 })
 export class DotFormDialogMockComponent {
-    @Input()
-    saveButtonDisabled: boolean;
+    @Input() saveButtonDisabled: boolean;
 
-    @Output()
-    save = new EventEmitter();
+    @Output() save = new EventEmitter();
 
-    @Output()
-    cancel = new EventEmitter();
+    @Output() cancel = new EventEmitter();
 }
 
 @Component({
@@ -252,15 +249,13 @@ describe('DotTemplatePropsComponent', () => {
             dialog.triggerEventHandler('save', {});
 
             expect(dialogConfig.data.onSave).toHaveBeenCalledTimes(1);
-            expect(dialogRef.close).toHaveBeenCalledTimes(1);
+            expect(dialogRef.close).toHaveBeenCalledOnceWith(false);
         });
 
-        it('should call save from config', () => {
+        it('should call cancel from config', () => {
             const dialog = de.query(By.css('[data-testId="dialogForm"]'));
             dialog.triggerEventHandler('cancel', {});
-
-            expect(dialogConfig.data.onCancel).toHaveBeenCalledTimes(1);
-            expect(dialogRef.close).toHaveBeenCalledTimes(1);
+            expect(dialogRef.close).toHaveBeenCalledOnceWith(true);
         });
     });
 });

--- a/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.ts
+++ b/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.ts
@@ -53,7 +53,7 @@ export class DotTemplatePropsComponent implements OnInit {
      */
     onSave(): void {
         this.config.data?.onSave?.(this.form.value);
-        this.ref.close();
+        this.ref.close(false);
     }
 
     /**
@@ -62,7 +62,6 @@ export class DotTemplatePropsComponent implements OnInit {
      * @memberof DotTemplatePropsComponent
      */
     onCancel(): void {
-        this.config.data?.onCancel?.();
-        this.ref.close();
+        this.ref.close(true);
     }
 }


### PR DESCRIPTION
ll dialogs in template portlet should close when user press ESC key. We do that in Content type.