### PR TITLE
dotCMS/core#19868  Containers pagination needs double click to change on templates portlet

### DIFF
--- a/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.html
+++ b/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.html
@@ -59,7 +59,7 @@
         (onLazyLoad)="paginate($event)"
         [lazy]="true"
         [pageLinks]="pageLinkSize"
-        [paginator]="totalRecords > rows"
+        [paginator]="true"
         [rows]="rows"
         [totalRecords]="totalRecords"
         [value]="options"

--- a/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.html
+++ b/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.html
@@ -59,7 +59,7 @@
         (onLazyLoad)="paginate($event)"
         [lazy]="true"
         [pageLinks]="pageLinkSize"
-        [paginator]="true"
+        [paginator]="totalRecords > rows"
         [rows]="rows"
         [totalRecords]="totalRecords"
         [value]="options"

--- a/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.ts
+++ b/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.ts
@@ -164,7 +164,7 @@ export class SearchableDropdownComponent
     }
 
     ngAfterContentInit() {
-        this.totalRecords = this.totalRecords || this.data.length;
+        this.totalRecords = this.totalRecords || this.data?.length;
         this.templates.forEach((item: PrimeTemplate) => {
             if (item.getType() === 'listItem') {
                 this.externalItemListTemplate = item.template;

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.html
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.html
@@ -10,7 +10,7 @@
     placeholder="{{ 'editpage.container.add.label' | dm }}"
     persistentPlaceholder="true"
     width="172px"
-    overlayWidth="300px"
+    overlayWidth="440px"
     [class]="innerClass"
     [multiple]="true"
 >

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.html
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.html
@@ -1,4 +1,5 @@
 <dot-searchable-dropdown
+    data-testId="searchableDropdown"
     (change)="containerChange($event)"
     (filterChange)="handleFilterChange($event)"
     (pageChange)="handlePageChange($event)"

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.html
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.html
@@ -2,7 +2,7 @@
     (change)="containerChange($event)"
     (filterChange)="handleFilterChange($event)"
     (pageChange)="handlePageChange($event)"
-    [data]="currentContainers"
+    [data]="currentContainers | async"
     [pageLinkSize]="5"
     [rows]="paginationService.paginationPerPage"
     [totalRecords]="paginationService.totalRecords"

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.spec.ts
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.spec.ts
@@ -26,9 +26,12 @@ import {
 } from 'dotcms-js';
 import { CoreWebServiceMock } from '@tests/core-web.service.mock';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import {
+    PaginationEvent,
+    SearchableDropdownComponent
+} from '@components/_common/searchable-dropdown/component';
 
 describe('ContainerSelectorComponent', () => {
-    let comp: DotContainerSelectorComponent;
     let fixture: ComponentFixture<DotContainerSelectorComponent>;
     let de: DebugElement;
     let searchableDropdownComponent;
@@ -65,7 +68,6 @@ describe('ContainerSelectorComponent', () => {
         }).compileComponents();
 
         fixture = DOTTestBed.createComponent(DotContainerSelectorComponent);
-        comp = fixture.componentInstance;
         de = fixture.debugElement;
 
         searchableDropdownComponent = de.query(By.css('dot-searchable-dropdown')).componentInstance;
@@ -165,10 +167,12 @@ describe('ContainerSelectorComponent', () => {
         fixture.detectChanges();
         const paginatorService: PaginatorService = de.injector.get(PaginatorService);
         spyOn(paginatorService, 'getWithOffset').and.returnValue(observableOf(containers));
-        comp.handleFilterChange('');
-        comp.currentContainers.subscribe((items: DotContainer[]) => {
-            expect(items[0].identifier).toEqual('427c47a4-c380-439f');
-            expect(items[1].identifier).toEqual('container/path');
-        });
+        const searchable: SearchableDropdownComponent = de.query(
+            By.css('[data-testId="searchableDropdown"]')
+        ).componentInstance;
+        searchable.pageChange.emit({ filter: '', first: 0 } as PaginationEvent);
+        fixture.detectChanges();
+        expect(searchable.data[0].identifier).toEqual('427c47a4-c380-439f');
+        expect(searchable.data[1].identifier).toEqual('container/path');
     });
 });

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.spec.ts
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.spec.ts
@@ -101,19 +101,17 @@ describe('ContainerSelectorComponent', () => {
 
     it('should pass all the right attr', () => {
         fixture.detectChanges();
-        const searchable = de.query(By.css('dot-searchable-dropdown'));
+        const searchable = de.query(By.css('[data-testId="searchableDropdown"]'));
         expect(searchable.attributes).toEqual(
             jasmine.objectContaining({
-                'ng-reflect-data': '',
                 'ng-reflect-label-property-name': 'name,parentPermissionable.host',
                 'ng-reflect-multiple': 'true',
-                'ng-reflect-overlay-width': '300px',
                 'ng-reflect-page-link-size': '5',
                 'ng-reflect-persistent-placeholder': 'true',
                 'ng-reflect-placeholder': 'editpage.container.add.label',
-                'ng-reflect-rows': '40',
+                'ng-reflect-rows': '5',
                 'ng-reflect-width': '172px',
-                overlayWidth: '300px',
+                overlayWidth: '440px',
                 persistentPlaceholder: 'true',
                 width: '172px'
             })
@@ -168,8 +166,9 @@ describe('ContainerSelectorComponent', () => {
         const paginatorService: PaginatorService = de.injector.get(PaginatorService);
         spyOn(paginatorService, 'getWithOffset').and.returnValue(observableOf(containers));
         comp.handleFilterChange('');
-
-        expect(comp.currentContainers[0].identifier).toEqual('427c47a4-c380-439f');
-        expect(comp.currentContainers[1].identifier).toEqual('container/path');
+        comp.currentContainers.subscribe((items: DotContainer[]) => {
+            expect(items[0].identifier).toEqual('427c47a4-c380-439f');
+            expect(items[1].identifier).toEqual('container/path');
+        });
     });
 });

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
@@ -65,10 +65,7 @@ export class DotContainerSelectorComponent implements OnInit {
         this.paginationService.filter = filter;
         this.currentContainers = this.paginationService.getWithOffset(offset).pipe(
             take(1),
-            map((items) => {
-                this.totalRecords = this.totalRecords || this.paginationService.totalRecords;
-                return this.setIdentifierReference(items.splice(0));
-            })
+            map((items: DotContainer[]) => this.setIdentifierReference(items.splice(0)))
         );
     }
 

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input, ChangeDetectorRef } from '@angular/core';
 
 import { PaginatorService } from '@services/paginator/paginator.service';
 import { DotTemplateContainersCacheService } from '@services/dot-template-containers-cache/dot-template-containers-cache.service';
@@ -22,11 +22,13 @@ export class DotContainerSelectorComponent implements OnInit {
 
     constructor(
         public paginationService: PaginatorService,
-        private templateContainersCacheService: DotTemplateContainersCacheService
+        private templateContainersCacheService: DotTemplateContainersCacheService,
+        private cd: ChangeDetectorRef
     ) {}
 
     ngOnInit(): void {
         this.paginationService.url = 'v1/containers';
+        this.paginationService.paginationPerPage = 5;
     }
 
     /**
@@ -55,14 +57,17 @@ export class DotContainerSelectorComponent implements OnInit {
      * @memberof DotContainerSelectorComponent
      */
     handlePageChange(event: any): void {
+        console.log('handlePageChange', event.filter, event.first);
         this.getContainersList(event.filter, event.first);
     }
 
     private getContainersList(filter = '', offset = 0): void {
+        console.log('getContainersList');
         this.paginationService.filter = filter;
         this.paginationService.getWithOffset(offset).subscribe((items) => {
             this.currentContainers = this.setIdentifierReference(items.splice(0));
             this.totalRecords = this.totalRecords || this.paginationService.totalRecords;
+            this.cd.detectChanges();
         });
     }
 

--- a/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
+++ b/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
@@ -62,7 +62,6 @@ export class DotContainerSelectorComponent implements OnInit {
     }
 
     private getContainersList(filter = '', offset = 0): void {
-        console.log('getContainersList');
         this.paginationService.filter = filter;
         this.currentContainers = this.paginationService.getWithOffset(offset).pipe(
             take(1),


### PR DESCRIPTION
When you have multiple containers and need to paginate to add into a container using the new templates portlet, you need double click in the number to reload the list. We need do this just with one click