### PR TITLE
dotCMS/core#19772 We are not redirecting properly when the session expires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dotcms-ui",
-    "version": "21.01.0",
+    "version": "21.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/projects/dotcms-js/src/lib/core/login.service.ts
+++ b/projects/dotcms-js/src/lib/core/login.service.ts
@@ -319,7 +319,7 @@ export class LoginService {
      * @returns Observable<any>
      */
     private logOutUser(): void {
-        window.location.href = LOGOUT_URL;
+        window.location.href = `${LOGOUT_URL}?r=${new Date().getTime()}`;
     }
 }
 

--- a/src/app/api/services/dot-router/dot-router.service.spec.ts
+++ b/src/app/api/services/dot-router/dot-router.service.spec.ts
@@ -262,4 +262,20 @@ describe('DotRouterService', () => {
             jasmine.clock().uninstall();
         });
     });
+
+    describe('go to logout', () => {
+        beforeEach(() => {
+            const mockDate = new Date(1466424490000);
+            jasmine.clock().install();
+            jasmine.clock().mockDate(mockDate);
+        });
+
+        it('should add the cache busting', () => {
+            service.doLogOut();
+            expect(router.navigate).toHaveBeenCalledWith(['/dotAdmin/logout'], {
+                queryParams: { r: 1466424490000 }
+            });
+            jasmine.clock().uninstall();
+        });
+    });
 });

--- a/src/app/api/services/dot-router/dot-router.service.ts
+++ b/src/app/api/services/dot-router/dot-router.service.ts
@@ -186,7 +186,7 @@ export class DotRouterService {
      * @memberof DotRouterService
      */
     doLogOut(): void {
-        window.location.href = LOGOUT_URL;
+        this.router.navigate([LOGOUT_URL], this.addCacheBusting());
     }
 
     /**
@@ -319,7 +319,7 @@ export class DotRouterService {
         }
     }
 
-    private addCacheBusting(navExtras: NavigationExtras): NavigationExtras {
+    private addCacheBusting(navExtras?: NavigationExtras): NavigationExtras {
         if (navExtras) {
             navExtras.queryParams['r'] = new Date().getTime();
         } else {

--- a/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
+++ b/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
@@ -42,7 +42,7 @@ import { dotEventSocketURLFactory, MockDotUiColorsService } from '@tests/dot-tes
 import { FormatDateService } from '@services/format-date-service';
 import { DotUiColorsService } from '@services/dot-ui-colors/dot-ui-colors.service';
 
-fdescribe('DotToolbarUserComponent', () => {
+describe('DotToolbarUserComponent', () => {
     let comp: DotToolbarUserComponent;
     let fixture: ComponentFixture<DotToolbarUserComponent>;
     let de: DebugElement;
@@ -103,6 +103,10 @@ fdescribe('DotToolbarUserComponent', () => {
             ]
         });
 
+        const mockDate = new Date(1466424490000);
+        jasmine.clock().install();
+        jasmine.clock().mockDate(mockDate);
+
         fixture = TestBed.createComponent(DotToolbarUserComponent);
         comp = fixture.componentInstance;
         de = fixture.debugElement;
@@ -112,10 +116,11 @@ fdescribe('DotToolbarUserComponent', () => {
         dotNavigationService = de.injector.get(DotNavigationService);
     });
 
+    afterEach(() => {
+        jasmine.clock().uninstall();
+    });
+
     it('should have correct href in logout link', () => {
-        const mockDate = new Date(1466424490000);
-        jasmine.clock().install();
-        jasmine.clock().mockDate(mockDate);
         comp.auth = {
             user: mockUser(),
             loginAsUser: null
@@ -127,8 +132,7 @@ fdescribe('DotToolbarUserComponent', () => {
         fixture.detectChanges();
 
         const logoutLink = de.query(By.css('#dot-toolbar-user-link-logout'));
-        expect(logoutLink.attributes.href).toBe('/dotAdmin/logoutr=1466424490000');
-        jasmine.clock().uninstall();
+        expect(logoutLink.attributes.href).toBe('/dotAdmin/logout?r=1466424490000');
     });
 
     it('should call "logoutAs" in "LoginService" on logout click', async () => {

--- a/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
+++ b/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
@@ -42,7 +42,7 @@ import { dotEventSocketURLFactory, MockDotUiColorsService } from '@tests/dot-tes
 import { FormatDateService } from '@services/format-date-service';
 import { DotUiColorsService } from '@services/dot-ui-colors/dot-ui-colors.service';
 
-describe('DotToolbarUserComponent', () => {
+fdescribe('DotToolbarUserComponent', () => {
     let comp: DotToolbarUserComponent;
     let fixture: ComponentFixture<DotToolbarUserComponent>;
     let de: DebugElement;
@@ -113,6 +113,9 @@ describe('DotToolbarUserComponent', () => {
     });
 
     it('should have correct href in logout link', () => {
+        const mockDate = new Date(1466424490000);
+        jasmine.clock().install();
+        jasmine.clock().mockDate(mockDate);
         comp.auth = {
             user: mockUser(),
             loginAsUser: null
@@ -124,7 +127,8 @@ describe('DotToolbarUserComponent', () => {
         fixture.detectChanges();
 
         const logoutLink = de.query(By.css('#dot-toolbar-user-link-logout'));
-        expect(logoutLink.attributes.href).toBe('/dotAdmin/logout');
+        expect(logoutLink.attributes.href).toBe('/dotAdmin/logoutr=1466424490000');
+        jasmine.clock().uninstall();
     });
 
     it('should call "logoutAs" in "LoginService" on logout click', async () => {

--- a/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
+++ b/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
@@ -18,7 +18,7 @@ export class DotToolbarUserComponent implements OnInit {
     showLoginAs = false;
     showMyAccount = false;
 
-    logoutUrl = LOGOUT_URL;
+    logoutUrl = `${LOGOUT_URL}?r=${new Date().getTime()}`;
 
     constructor(
         @Inject(LOCATION_TOKEN) private location: Location,
@@ -42,6 +42,7 @@ export class DotToolbarUserComponent implements OnInit {
      * @memberof ToolbarUserComponent
      */
     logout(): boolean {
+        debugger;
         this.dotRouterService.doLogOut();
         return false;
     }

--- a/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
+++ b/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
@@ -42,7 +42,6 @@ export class DotToolbarUserComponent implements OnInit {
      * @memberof ToolbarUserComponent
      */
     logout(): boolean {
-        debugger;
         this.dotRouterService.doLogOut();
         return false;
     }


### PR DESCRIPTION
When you leave an active session for a while and this expire, we invalidate the sessions and should redirect to the logout, but when this is happening we are just showing a blank page with a 404 error.