### PR TITLE
dotCMS/core#19917 Sign in button redirect to recover password while recovering the password

### DIFF
--- a/src/app/api/services/dot-router/dot-router.service.spec.ts
+++ b/src/app/api/services/dot-router/dot-router.service.spec.ts
@@ -80,7 +80,7 @@ describe('DotRouterService', () => {
 
     it('should set previous & current url value', () => {
         router.triggerNavigationEnd('/newUrl');
-        expect(service.previousSavedURL).toEqual('/c/test');
+        expect(service.routeHistory).toEqual({ url: '/newUrl', previousUrl: '/c/test' });
         expect(service.currentSavedURL).toEqual('/newUrl');
     });
 
@@ -148,7 +148,7 @@ describe('DotRouterService', () => {
     });
 
     it('should go to previousSavedURL when goToMain() called', () => {
-        service.previousSavedURL = 'test/fake';
+        service.routeHistory = { previousUrl: 'test/fake', url: '/' };
         service.goToPreviousUrl();
         expect(router.navigate).toHaveBeenCalledWith(['test/fake']);
     });

--- a/src/app/api/services/dot-router/dot-router.service.spec.ts
+++ b/src/app/api/services/dot-router/dot-router.service.spec.ts
@@ -141,13 +141,13 @@ describe('DotRouterService', () => {
         expect(router.navigate).toHaveBeenCalledWith(['/Form/edit/123']);
     });
 
-    it('should go to previousSavedURL', () => {
-        service.previousSavedURL = 'test/fake';
+    it('should go to storedRedirectUrl', () => {
+        service.storedRedirectUrl = 'test/fake';
         service.goToMain();
         expect(router.navigate).toHaveBeenCalledWith(['test/fake']);
     });
 
-    it('should go to previousSavedURL when goToMain() called', () => {
+    it('should go to previous URL when goToMain() called', () => {
         service.routeHistory = { previousUrl: 'test/fake', url: '/' };
         service.goToPreviousUrl();
         expect(router.navigate).toHaveBeenCalledWith(['test/fake']);

--- a/src/app/api/services/dot-router/dot-router.service.ts
+++ b/src/app/api/services/dot-router/dot-router.service.ts
@@ -11,7 +11,7 @@ import { filter } from 'rxjs/operators';
 @Injectable()
 export class DotRouterService {
     portletReload$ = new Subject();
-    private _previousSavedURL: string;
+    private _storedRedirectUrl: string;
     private _routeHistory: PortletNav = { url: '' };
     private CUSTOM_PORTLET_ID_PREFIX = 'c_';
 
@@ -38,12 +38,12 @@ export class DotRouterService {
         };
     }
 
-    set previousSavedURL(url: string) {
-        this._previousSavedURL = url;
+    set storedRedirectUrl(url: string) {
+        this._storedRedirectUrl = url;
     }
 
-    get previousSavedURL(): string {
-        return this._previousSavedURL;
+    get storedRedirectUrl(): string {
+        return this._storedRedirectUrl;
     }
 
     get routeHistory(): PortletNav {
@@ -116,7 +116,7 @@ export class DotRouterService {
     }
 
     /**
-     * Go to first porlet unless userEditPageRedirect is passed or previousSavedURL is set
+     * Go to first porlet unless userEditPageRedirect is passed or storedRedirectUrl is set
      *
      * @param string [userEditPageRedirect]
      * @returns Promise<boolean>
@@ -321,9 +321,9 @@ export class DotRouterService {
     }
 
     private redirectMain(): Promise<boolean> {
-        if (this.previousSavedURL) {
-            return this.router.navigate([this.previousSavedURL]).then((ok: boolean) => {
-                this.previousSavedURL = null;
+        if (this.storedRedirectUrl) {
+            return this.router.navigate([this.storedRedirectUrl]).then((ok: boolean) => {
+                this.storedRedirectUrl = null;
                 return ok;
             });
         } else {

--- a/src/app/api/services/dot-router/dot-router.service.ts
+++ b/src/app/api/services/dot-router/dot-router.service.ts
@@ -20,7 +20,6 @@ export class DotRouterService {
         this.router.events
             .pipe(filter((event: Event) => event instanceof NavigationEnd))
             .subscribe((event: NavigationEnd) => {
-                debugger;
                 this.routeHistory = {
                     url: event.url,
                     previousUrl: this._routeHistory.url

--- a/src/app/api/services/dot-router/dot-router.service.ts
+++ b/src/app/api/services/dot-router/dot-router.service.ts
@@ -6,21 +6,26 @@ import { Subject } from 'rxjs';
 import { DotAppsSites } from '@shared/models/dot-apps/dot-apps.model';
 import { NavigationExtras } from '@angular/router';
 import { LOGOUT_URL } from 'dotcms-js';
+import { filter } from 'rxjs/operators';
 
 @Injectable()
 export class DotRouterService {
     portletReload$ = new Subject();
+    private _previousSavedURL: string;
     private _routeHistory: PortletNav = { url: '' };
     private CUSTOM_PORTLET_ID_PREFIX = 'c_';
 
     constructor(private router: Router, private route: ActivatedRoute) {
         this._routeHistory.url = this.router.url;
-        this.router.events.subscribe((event: Event) => {
-            if (event instanceof NavigationEnd) {
-                this._routeHistory.previousUrl = this._routeHistory.url;
-                this._routeHistory.url = event.url;
-            }
-        });
+        this.router.events
+            .pipe(filter((event: Event) => event instanceof NavigationEnd))
+            .subscribe((event: NavigationEnd) => {
+                debugger;
+                this.routeHistory = {
+                    url: event.url,
+                    previousUrl: this._routeHistory.url
+                };
+            });
     }
 
     get currentSavedURL(): string {
@@ -34,12 +39,20 @@ export class DotRouterService {
         };
     }
 
-    get previousSavedURL(): string {
-        return this._routeHistory.previousUrl;
+    set previousSavedURL(url: string) {
+        this._previousSavedURL = url;
     }
 
-    set previousSavedURL(url: string) {
-        this._routeHistory.previousUrl = url;
+    get previousSavedURL(): string {
+        return this._previousSavedURL;
+    }
+
+    get routeHistory(): PortletNav {
+        return this._routeHistory;
+    }
+
+    set routeHistory(value: PortletNav) {
+        this._routeHistory = value;
     }
 
     get queryParams(): Params {
@@ -54,7 +67,7 @@ export class DotRouterService {
      * @memberof DotRouterService
      */
     goToPreviousUrl(): void {
-        this.router.navigate([this.previousSavedURL]);
+        this.router.navigate([this.routeHistory.previousUrl]);
     }
 
     /**
@@ -309,9 +322,9 @@ export class DotRouterService {
     }
 
     private redirectMain(): Promise<boolean> {
-        if (this._routeHistory.previousUrl) {
+        if (this.previousSavedURL) {
             return this.router.navigate([this.previousSavedURL]).then((ok: boolean) => {
-                this._routeHistory.url = null;
+                this.previousSavedURL = null;
                 return ok;
             });
         } else {

--- a/src/app/api/services/guards/auth-guard.service.ts
+++ b/src/app/api/services/guards/auth-guard.service.ts
@@ -17,7 +17,7 @@ export class AuthGuardService implements CanActivate {
             map((isLogin) => {
                 if (!isLogin) {
                     this.dotRouterService.goToLogin();
-                    this.dotRouterService.previousSavedURL = state.url;
+                    this.dotRouterService.storedRedirectUrl = state.url;
                 }
                 return isLogin;
             })

--- a/src/app/test/dot-router-service.mock.ts
+++ b/src/app/test/dot-router-service.mock.ts
@@ -26,15 +26,15 @@ export class MockDotRouterService {
         this._currentSavedURL = url;
     }
 
-    get previousSavedURL(): string {
-        return this._previousSavedURL;
+    get storedRedirectUrl(): string {
+        return this._storedRedirectUrl;
     }
 
-    set previousSavedURL(url: string) {
-        this._previousSavedURL = url;
+    set storedRedirectUrl(url: string) {
+        this._storedRedirectUrl = url;
     }
 
-    _previousSavedURL = '';
+    _storedRedirectUrl = '';
     _currentSavedURL = '';
     replaceQueryParams = jasmine.createSpy('replaceQueryParams');
     getPortletId = jasmine.createSpy('getPortletId').and.returnValue('test');

--- a/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.spec.ts
+++ b/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.spec.ts
@@ -76,7 +76,7 @@ describe('DotSubNavComponent', () => {
 
         component.itemClick.subscribe((event) => {
             expect(event).toEqual({
-                originalEvent: { hello: 'world' },
+                originalEvent: ({ hello: 'world' } as unknown) as MouseEvent,
                 data: data.menuItems[0]
             });
         });


### PR DESCRIPTION
We need to leave the `previousSavedURL ` as it was; only the `auth-guard.service.ts` is in charge to keep updated that value. Beside that I leave the `routeHistory ` functionality that will be needed by Alfredo.  