### PR TITLE
Fixed overflow bug in content types

### DIFF
--- a/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
+++ b/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
@@ -34,10 +34,10 @@
         class="content-type__properties"
         header="{{ 'contenttypes.tab.fields.header' | dm }}"
     >
-        <div class="content-type__fields-layout">
-            <dot-portlet-box class="content-type__fields-main">
+        <div class="content-type__fields-layout" id="content-type-form-layout">
+            <div class="content-type__fields-main" id="content-type-form-main">
                 <ng-content></ng-content>
-            </dot-portlet-box>
+            </div>
             <div class="content-type__fields-sidebar">
                 <p-splitButton
                     icon="pi pi-plus"

--- a/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
+++ b/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
@@ -56,8 +56,12 @@ $top-height: ($toolbar-height + $tabview-nav-height + $dot-secondary-toolbar-mai
     }
 
     .content-type__fields-main {
+        background-color: $gray-bg;
         display: flex;
+        flex-direction: column;
         flex-grow: 1;
+        overflow: auto;
+        padding: $spacing-3;
     }
 
     .content-type__fields-layout {

--- a/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
+++ b/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
@@ -81,7 +81,7 @@ const fakeContentType: DotCMSContentType = {
     baseType: 'testBaseType'
 };
 
-fdescribe('ContentTypesLayoutComponent', () => {
+describe('ContentTypesLayoutComponent', () => {
     let fixture: ComponentFixture<TestHostComponent>;
     let de: DebugElement;
 

--- a/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
+++ b/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
@@ -81,7 +81,7 @@ const fakeContentType: DotCMSContentType = {
     baseType: 'testBaseType'
 };
 
-describe('ContentTypesLayoutComponent', () => {
+fdescribe('ContentTypesLayoutComponent', () => {
     let fixture: ComponentFixture<TestHostComponent>;
     let de: DebugElement;
 
@@ -160,35 +160,6 @@ describe('ContentTypesLayoutComponent', () => {
         fixture.detectChanges();
         expect(fieldDragDropService.setBagOptions).toHaveBeenCalledTimes(1);
     });
-
-    it('should always have dot-portlet-box in the first tab', fakeAsync(() => {
-        fixture.componentInstance.contentType = fakeContentType;
-        fixture.detectChanges();
-
-        // We click a random tab and the first tab should always have the dot-portlet-box
-        const thirdTabLink = de.query(By.css('ul.p-tabview-nav li:nth-child(3) > a'));
-        thirdTabLink.nativeElement.click();
-        fixture.detectChanges();
-
-        fixture.whenStable().then(() => {
-            const firstTab = de.query(By.css('.content-type__properties'));
-            const firstTabPortletBox = firstTab.query(By.css('dot-portlet-box'));
-            expect(firstTabPortletBox).not.toBeNull();
-        });
-    }));
-
-    it("should have first tab's dot-portlet-box inside of content-type__fields-layout", fakeAsync(() => {
-        fixture.componentInstance.contentType = fakeContentType;
-        fixture.detectChanges();
-
-        fixture.whenStable().then(() => {
-            const firstTab = de.query(By.css('.content-type__properties'));
-            const firstTabPortletBox = firstTab.query(By.css('dot-portlet-box'));
-            expect(firstTabPortletBox.nativeElement.parentNode.classList).toContain(
-                'content-type__fields-layout'
-            );
-        });
-    }));
 
     it('should have dot-portlet-box in the second tab after it has been clicked', fakeAsync(() => {
         fixture.componentInstance.contentType = fakeContentType;


### PR DESCRIPTION
Fixed an overflow bug in the `content-types-angular/edit/` screen.