### PR TITLE
dotCMS/core#20022 Fix JS error while creating a template.

### DIFF
--- a/projects/dotcms-js/src/lib/core/core-web.service.ts
+++ b/projects/dotcms-js/src/lib/core/core-web.service.ts
@@ -261,15 +261,14 @@ export class CoreWebService {
     }
 
     private getFixedUrl(url: string): string {
-        if (url.startsWith('api')) {
+        if (url?.startsWith('api')) {
             return `/${url}`;
         }
 
-        const [version] = url.split('/');
+        const version = url ? url.split('/')[0] : '';
         if (version.match(/v[1-9]/g)) {
             return `/api/${url}`;
         }
-
         return url;
     }
 

--- a/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
+++ b/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
@@ -168,7 +168,6 @@ describe('DotThemeSelectorDropdownComponent', () => {
         describe('html', () => {
             it('should set themes if theme selector is open', () => {
                 component.searchableDropdown.show.emit();
-                component.onShow();
                 expect(component.totalRecords).toEqual(3);
                 expect(component.themes).toEqual(mockDotThemes);
             });

--- a/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
+++ b/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
@@ -14,7 +14,10 @@ import { mockDotThemes } from '@tests/dot-themes.mock';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 import { MockDotMessageService } from '@tests/dot-message-service.mock';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
-import { SearchableDropdownComponent } from '@components/_common/searchable-dropdown/component/searchable-dropdown.component';
+import {
+    PaginationEvent,
+    SearchableDropdownComponent
+} from '@components/_common/searchable-dropdown/component/searchable-dropdown.component';
 import { SearchableDropDownModule } from '@components/_common/searchable-dropdown';
 import { DotIconModule } from '@components/_common/dot-icon/dot-icon.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -164,9 +167,25 @@ describe('DotThemeSelectorDropdownComponent', () => {
 
         describe('html', () => {
             it('should set themes if theme selector is open', () => {
+                component.searchableDropdown.show.emit();
                 component.onShow();
                 expect(component.totalRecords).toEqual(3);
                 expect(component.themes).toEqual(mockDotThemes);
+            });
+
+            it('should not call pagination service if the url is not set', () => {
+                component.currentSiteIdentifier = '123';
+                spyOn(paginationService, 'getWithOffset');
+                component.searchableDropdown.pageChange.emit({ first: 0 } as PaginationEvent);
+                expect(paginationService.getWithOffset).not.toHaveBeenCalled();
+            });
+
+            it('should not call pagination service if the url is not set', () => {
+                component.currentSiteIdentifier = '123';
+                component.paginatorService.url = 'v1/test';
+                spyOn(paginationService, 'getWithOffset');
+                component.searchableDropdown.pageChange.emit({ first: 10 } as PaginationEvent);
+                expect(paginationService.getWithOffset).toHaveBeenCalledWith(10);
             });
 
             it('should set the right attributes', () => {

--- a/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
+++ b/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
@@ -168,7 +168,7 @@ export class DotThemeSelectorDropdownComponent
      */
     handlePageChange(event: LazyLoadEvent): void {
         this.currentOffset = event.first;
-        if (this.currentSiteIdentifier) {
+        if (this.currentSiteIdentifier && this.paginatorService.url) {
             this.paginatorService
                 .getWithOffset(event.first)
                 /*


### PR DESCRIPTION
check `this.paginatorService.url` is set to avoid the first event of `pageChange` when initially loads, then the `this.paginatorService.url` is set on the `show` event. 