### PR TITLE
dotCMS/core#19772 The data for a SESSION_DESTROYED event not have the…

### DIFF
--- a/projects/dotcms-js/src/lib/core/login.service.ts
+++ b/projects/dotcms-js/src/lib/core/login.service.ts
@@ -56,7 +56,7 @@ export class LoginService {
             this.loggerService.debug('User Logged In Date: ', this.auth.user.loggedInDate);
 
             // if the destroyed event happens after the logged in date, so proceed!
-            if (this.auth.user.loggedInDate && !this.isLogoutAfterLastLogin(date)) {
+            if (this.auth.user.loggedInDate && this.isLogoutAfterLastLogin(date)) {
                 this.logOutUser();
             }
         });
@@ -278,6 +278,7 @@ export class LoginService {
      * @param _auth
      */
     public setAuth(auth: Auth): void {
+        auth.user.loggedInDate = new Date().getTime();
         this._auth = auth;
         this._auth$.next(auth);
 
@@ -317,6 +318,7 @@ export class LoginService {
      * @returns Observable<any>
      */
     private logOutUser(): void {
+        this.auth.user.loggedInDate = undefined;
         window.location.href = `${LOGOUT_URL}?r=${new Date().getTime()}`;
     }
 }

--- a/projects/dotcms-js/src/lib/core/login.service.ts
+++ b/projects/dotcms-js/src/lib/core/login.service.ts
@@ -4,7 +4,6 @@
 import { CoreWebService } from './core-web.service';
 import { Injectable } from '@angular/core';
 import { Observable, Subject, of } from 'rxjs';
-import { LoggerService } from './logger.service';
 import { HttpCode } from './util/http-code';
 import { pluck, tap, map } from 'rxjs/operators';
 import { DotcmsEventsService } from './dotcms-events.service';
@@ -35,8 +34,7 @@ export class LoginService {
 
     constructor(
         private coreWebService: CoreWebService,
-        private dotcmsEventsService: DotcmsEventsService,
-        private loggerService: LoggerService
+        private dotcmsEventsService: DotcmsEventsService
     ) {
         this._loginAsUsersList$ = <Subject<User[]>>new Subject();
         this.urls = {
@@ -51,15 +49,7 @@ export class LoginService {
         };
 
         // when the session is expired/destroyed
-        dotcmsEventsService.subscribeTo('SESSION_DESTROYED').subscribe((date) => {
-            this.loggerService.debug('Processing session destroyed: ', date);
-            this.loggerService.debug('User Logged In Date: ', this.auth.user.loggedInDate);
-
-            // if the destroyed event happens after the logged in date, so proceed!
-            if (this.auth.user.loggedInDate && this.isLogoutAfterLastLogin(date)) {
-                this.logOutUser();
-            }
-        });
+        dotcmsEventsService.subscribeTo('SESSION_DESTROYED').subscribe(() => this.logOutUser());
     }
 
     get loginAsUsersList$(): Observable<User[]> {
@@ -278,7 +268,6 @@ export class LoginService {
      * @param _auth
      */
     public setAuth(auth: Auth): void {
-        auth.user.loggedInDate = new Date().getTime();
         this._auth = auth;
         this._auth$.next(auth);
 
@@ -288,14 +277,6 @@ export class LoginService {
         } else {
             this.dotcmsEventsService.start();
         }
-    }
-
-    private isLogoutAfterLastLogin(date): boolean {
-        return (
-            this.auth?.user?.loggedInDate &&
-            date &&
-            Number(date) > Number(this.auth.user.loggedInDate)
-        );
     }
 
     /**
@@ -318,7 +299,6 @@ export class LoginService {
      * @returns Observable<any>
      */
     private logOutUser(): void {
-        this.auth.user.loggedInDate = undefined;
         window.location.href = `${LOGOUT_URL}?r=${new Date().getTime()}`;
     }
 }
@@ -352,7 +332,6 @@ export interface User {
     type?: string;
     userId: string;
     password?: string;
-    loggedInDate: number; // Timestamp
 }
 
 export interface Auth {

--- a/projects/dotcms-js/src/lib/core/login.service.ts
+++ b/projects/dotcms-js/src/lib/core/login.service.ts
@@ -56,7 +56,7 @@ export class LoginService {
             this.loggerService.debug('User Logged In Date: ', this.auth.user.loggedInDate);
 
             // if the destroyed event happens after the logged in date, so proceed!
-            if (this.auth.user.loggedInDate && this.isLogoutAfterLastLogin(date)) {
+            if (this.auth.user.loggedInDate && !this.isLogoutAfterLastLogin(date)) {
                 this.logOutUser();
             }
         });
@@ -214,7 +214,6 @@ export class LoginService {
                     this.coreWebService
                         .subscribeToHttpError(HttpCode.UNAUTHORIZED)
                         .subscribe(() => {
-                            console.log('login logout');
                             this.logOutUser();
                         });
                     return response.entity;
@@ -279,7 +278,6 @@ export class LoginService {
      * @param _auth
      */
     public setAuth(auth: Auth): void {
-        auth.user.loggedInDate = new Date().getTime();
         this._auth = auth;
         this._auth$.next(auth);
 
@@ -319,7 +317,6 @@ export class LoginService {
      * @returns Observable<any>
      */
     private logOutUser(): void {
-        this.auth.user.loggedInDate = undefined;
         window.location.href = `${LOGOUT_URL}?r=${new Date().getTime()}`;
     }
 }

--- a/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.spec.ts
+++ b/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.spec.ts
@@ -104,7 +104,6 @@ describe('DotLoginAsComponent', () => {
             emailAddress: 'a@a.com',
             firstName: 'user_first_name',
             lastName: 'user_lastname',
-            loggedInDate: 1,
             name: 'user 1',
             userId: '1'
         }


### PR DESCRIPTION
I removed this condition

https://github.com/dotCMS/core-web/pull/1610/files#diff-cd0ba6e2364eca90ea6a4f00fe17b2869f58b1ab31a8abbd2a16b48674914ea4L

this condition was there because before we sent the SESSION_DETROYED every time the HttpSession was detroyed, it could happened when you did a logout or by Time Ou, so if you logout then you after while receive the SESSION_DETROYED event and really you got logout twice.

After this change in backend the SESSION_DETROYED is just sent by TIME_OUT, so the condition is not needed enymore

https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotcms/listeners/SessionMonitor.java#L124