### PR TITLE
dotCMS/core#20100 Update theme selector to include system host

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.html
@@ -9,7 +9,7 @@
     [data]="sitesCurrentPage"
     [ngModel]="currentSite$ | async"
     [pageLinkSize]="3"
-    [rows]="10"
+    [rows]="pageSize"
     [totalRecords]="paginationService.totalRecords"
     [class]="'site-selector__field ' + cssClass"
     [width]="width"

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
@@ -215,17 +215,30 @@ describe('SiteSelectorComponent', () => {
         expect(result).toEqual({ fake: 'site' });
     });
 
-    xit('should set current site correctly', async () => {
+    it('should set current site correctly', async () => {
         paginatorService.filter = 'filter';
         paginatorService.totalRecords = 2;
         spyOn(paginatorService, 'getWithOffset').and.returnValue(observableOf([]));
         spyOn(comp, 'handleSitesRefresh');
-        fixture.detectChanges();
-        await fixture.whenStable();
-
         comp.currentSite$.subscribe((res) => {
             expect(res).toEqual(mockSites[0]);
         });
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should set site based on passed id', async () => {
+        paginatorService.filter = 'filter';
+        paginatorService.totalRecords = 2;
+        comp.id = mockSites[1].identifier;
+        spyOn(paginatorService, 'getWithOffset').and.returnValue(observableOf(mockSites));
+        spyOn(siteService, 'getSiteById').and.returnValue(observableOf(mockSites[1]));
+        spyOnProperty(siteService, 'currentSite', 'get').and.returnValue(mockSites[0]);
+        comp.currentSite$.subscribe((res) => {
+            expect(res).toEqual(mockSites[1]);
+        });
+        fixture.detectChanges();
+        await fixture.whenStable();
     });
 
     it('should set current on switchSite$', () => {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
@@ -215,7 +215,7 @@ describe('SiteSelectorComponent', () => {
         expect(result).toEqual({ fake: 'site' });
     });
 
-    it('should set current site correctly', async () => {
+    it('should set current site correctly', () => {
         paginatorService.filter = 'filter';
         paginatorService.totalRecords = 2;
         spyOn(paginatorService, 'getWithOffset').and.returnValue(observableOf([]));
@@ -224,7 +224,6 @@ describe('SiteSelectorComponent', () => {
             expect(res).toEqual(mockSites[0]);
         });
         fixture.detectChanges();
-        await fixture.whenStable();
     });
 
     it('should set site based on passed id', async () => {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
@@ -38,6 +38,7 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
     @Input() system: boolean;
     @Input() cssClass: string;
     @Input() width: string;
+    @Input() pageSize = 10;
 
     @Output() change: EventEmitter<Site> = new EventEmitter();
     @Output() hide: EventEmitter<any> = new EventEmitter();
@@ -67,6 +68,7 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
         this.paginationService.setExtraParams('archive', this.archive);
         this.paginationService.setExtraParams('live', this.live);
         this.paginationService.setExtraParams('system', this.system);
+        this.paginationService.paginationPerPage = this.pageSize;
 
         this.siteService.refreshSites$
             .pipe(takeUntil(this.destroy$))
@@ -159,6 +161,7 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof SiteSelectorComponent
      */
     handlePageChange(event): void {
+        console.log('handlePageChange');
         this.getSitesList(event.filter, event.first);
     }
 
@@ -169,11 +172,10 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof SiteSelectorComponent
      */
     getSitesList(filter = '', offset = 0): void {
-        // Set filter if undefined
-        Promise.resolve().then(() => this.updateCurrentSite(this.siteService.currentSite));
         this.paginationService.filter = filter;
         this.paginationService.getWithOffset(offset).subscribe((items) => {
             this.sitesCurrentPage = [...items];
+            this.setSelectedSite();
         });
     }
 
@@ -221,5 +223,16 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
     private updateValues(items: Site[]): void {
         this.sitesCurrentPage = [...items];
         this.updateCurrentSite(this.siteService.currentSite);
+    }
+
+    private setSelectedSite(): void {
+        if (this.id && this.siteService.currentSite.identifier !== this.id) {
+            this.siteService
+                .getSiteById(this.id)
+                .pipe(take(1))
+                .subscribe((selectedSite) => this.updateCurrentSite(selectedSite));
+        } else {
+            this.updateCurrentSite(this.siteService.currentSite);
+        }
     }
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
@@ -161,7 +161,6 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof SiteSelectorComponent
      */
     handlePageChange(event): void {
-        console.log('handlePageChange');
         this.getSitesList(event.filter, event.first);
     }
 
@@ -172,11 +171,14 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof SiteSelectorComponent
      */
     getSitesList(filter = '', offset = 0): void {
+        Promise.resolve().then(() => this.setSelectedSite());
         this.paginationService.filter = filter;
-        this.paginationService.getWithOffset(offset).subscribe((items) => {
-            this.sitesCurrentPage = [...items];
-            this.setSelectedSite();
-        });
+        this.paginationService
+            .getWithOffset(offset)
+            .pipe(take(1))
+            .subscribe((items: Site[]) => {
+                this.sitesCurrentPage = [...items];
+            });
     }
 
     /**

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.html
@@ -10,9 +10,11 @@
     <div class="dot-theme__header" data-testId="header">
         <dot-site-selector
             data-testId="siteSelector"
+            [id]="current.hostId"
             #siteSelector
             (change)="siteChange($event)"
             [archive]="false"
+            [system]="true"
         ></dot-site-selector>
         <div class="dot-theme-search-box">
             <dot-icon

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.html
@@ -10,7 +10,7 @@
     <div class="dot-theme__header" data-testId="header">
         <dot-site-selector
             data-testId="siteSelector"
-            [id]="current.hostId"
+            [id]="current?.hostId"
             #siteSelector
             (change)="siteChange($event)"
             [archive]="false"

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.spec.ts
@@ -1,16 +1,15 @@
 import { of } from 'rxjs';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { DotThemeSelectorComponent } from './dot-theme-selector.component';
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement, Input } from '@angular/core';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
 import { DotThemesService } from '@services/dot-themes/dot-themes.service';
 import { MockDotMessageService } from '../../../../../test/dot-message-service.mock';
 import { By } from '@angular/platform-browser';
 import { mockDotThemes } from '../../../../../test/dot-themes.mock';
 import { DataViewModule } from 'primeng/dataview';
-import { DotSiteSelectorModule } from '@components/_common/dot-site-selector/dot-site-selector.module';
 import { mockSites, SiteServiceMock } from '../../../../../test/site-service.mock';
-import { CoreWebService, SiteService } from '@dotcms/dotcms-js';
+import { CoreWebService, Site, SiteService } from '@dotcms/dotcms-js';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { PaginatorService } from '@services/paginator/paginator.service';
 import { DotThemesServiceMock } from '../../../../../test/dot-themes-service.mock';
@@ -20,6 +19,20 @@ import { CoreWebServiceMock } from '@tests/core-web.service.mock';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 import { DotEventsService } from '@services/dot-events/dot-events.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+@Component({
+    selector: 'dot-site-selector',
+    template: `<select>
+        <option>Fake site selector</option>
+    </select>`
+})
+class MockDotSiteSelectorComponent {
+    @Input() system;
+    @Input() archive;
+    searchableDropdown = {
+        handleClick: () => {}
+    };
+}
 
 describe('DotThemeSelectorComponent', () => {
     let component: DotThemeSelectorComponent;
@@ -37,10 +50,9 @@ describe('DotThemeSelectorComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [DotThemeSelectorComponent],
+            declarations: [DotThemeSelectorComponent, MockDotSiteSelectorComponent],
             imports: [
                 DataViewModule,
-                DotSiteSelectorModule,
                 BrowserAnimationsModule,
                 DotDialogModule,
                 DotIconModule,
@@ -87,6 +99,8 @@ describe('DotThemeSelectorComponent', () => {
                     By.css('[data-testId="header"] [data-testId="siteSelector"]')
                 );
                 expect(siteSelector).not.toBeNull();
+                expect(siteSelector.componentInstance.system).toEqual(true);
+                expect(siteSelector.componentInstance.archive).toEqual(false);
             });
 
             it('should have dot-icon', () => {
@@ -135,7 +149,7 @@ describe('DotThemeSelectorComponent', () => {
             expect(paginatorService.url).toBe('v1/themes');
             expect(paginatorService.setExtraParams).toHaveBeenCalledWith(
                 'hostId',
-                '123-xyz-567-xxl'
+                mockDotThemes[0].hostId
             );
             expect(paginatorService.deleteExtraParams).toHaveBeenCalledWith('searchParam');
         });
@@ -224,5 +238,29 @@ describe('DotThemeSelectorComponent', () => {
             expect(paginatorService.extraParams.get('searchParam')).toBe('test');
             expect(component.paginate).toHaveBeenCalled();
         }));
+    });
+
+    describe('User interaction empty', () => {
+        let siteService: SiteService;
+
+        beforeEach(() => {
+            siteService = TestBed.inject(SiteService);
+            spyOn(paginatorService, 'getWithOffset').and.returnValue(of([]));
+        });
+
+        it(' should set system host ', () => {
+            spyOn(siteService, 'getSiteById').and.returnValue(of({} as Site));
+            component.siteChange(mockSites[0]);
+            fixture.detectChanges();
+            expect(siteService.getSiteById).toHaveBeenCalledWith('SYSTEM_HOST');
+        });
+
+        xit(' should set system host just once ', () => {
+            spyOn(siteService, 'getSiteById').and.returnValue(of({} as Site));
+            component.siteChange(mockSites[0]);
+            fixture.detectChanges();
+            setTimeout(() => component.siteChange({ identifier: '123' } as Site), 0); // simulate user site change.
+            expect(siteService.getSiteById).toHaveBeenCalledOnceWith('SYSTEM_HOST');
+        });
     });
 });

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.spec.ts
@@ -250,14 +250,12 @@ describe('DotThemeSelectorComponent', () => {
 
         it(' should set system host ', () => {
             spyOn(siteService, 'getSiteById').and.returnValue(of({} as Site));
-            component.siteChange(mockSites[0]);
             fixture.detectChanges();
-            expect(siteService.getSiteById).toHaveBeenCalledWith('SYSTEM_HOST');
+            expect(siteService.getSiteById).toHaveBeenCalledOnceWith('SYSTEM_HOST');
         });
 
-        xit(' should set system host just once ', () => {
+        it(' should set system host just once ', () => {
             spyOn(siteService, 'getSiteById').and.returnValue(of({} as Site));
-            component.siteChange(mockSites[0]);
             fixture.detectChanges();
             setTimeout(() => component.siteChange({ identifier: '123' } as Site), 0); // simulate user site change.
             expect(siteService.getSiteById).toHaveBeenCalledOnceWith('SYSTEM_HOST');

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.ts
@@ -21,6 +21,7 @@ import { DotMessageService } from '@services/dot-message/dot-messages.service';
 import { PaginatorService } from '@services/paginator';
 import { DotDialogActions } from '@components/dot-dialog/dot-dialog.component';
 import { DotTheme } from '@models/dot-edit-layout-designer';
+import { DotSiteSelectorComponent } from '@components/_common/dot-site-selector/dot-site-selector.component';
 
 /**
  * The DotThemeSelectorComponent is modal that
@@ -51,12 +52,16 @@ export class DotThemeSelectorComponent implements OnInit, OnDestroy {
     @ViewChild('dataView', { static: true })
     dataView: DataView;
 
+    @ViewChild('siteSelector', { static: true })
+    siteSelector: DotSiteSelectorComponent;
+
     current: DotTheme;
     visible = true;
     dialogActions: DotDialogActions;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
     private SEARCH_PARAM = 'searchParam';
+    private initialLoad = true;
 
     constructor(
         private dotMessageService: DotMessageService,
@@ -78,12 +83,14 @@ export class DotThemeSelectorComponent implements OnInit, OnDestroy {
                 label: this.dotMessageService.get('dot.common.cancel')
             }
         };
+        this.current = this.value;
         this.paginatorService.url = 'v1/themes';
-        this.paginatorService.setExtraParams('hostId', this.siteService.currentSite.identifier);
+        this.paginatorService.setExtraParams(
+            'hostId',
+            this.current?.hostId || this.siteService.currentSite.identifier
+        );
         this.paginatorService.deleteExtraParams(this.SEARCH_PARAM);
         this.paginatorService.paginationPerPage = 8;
-        this.current = this.value;
-
         observableFromEvent(this.searchInput.nativeElement, 'keyup')
             .pipe(debounceTime(500), takeUntil(this.destroy$))
             .subscribe((keyboardEvent: Event) => {
@@ -103,12 +110,21 @@ export class DotThemeSelectorComponent implements OnInit, OnDestroy {
      * @memberof DotThemeSelectorComponent
      */
     paginate($event: LazyLoadEvent): void {
+        debugger;
         this.paginatorService
             .getWithOffset($event.first)
             .pipe(take(1))
             .subscribe((themes: DotTheme[]) => {
-                this.themes = themes;
-                this.cd.detectChanges();
+                if (this.isSitesWithoutThemes(themes, $event)) {
+                    this.siteService.getSiteById('SYSTEM_HOST').subscribe((site: Site) => {
+                        this.siteSelector.searchableDropdown.handleClick(site);
+                        this.cd.detectChanges();
+                    });
+                } else {
+                    this.themes = themes;
+                    this.cd.detectChanges();
+                }
+                this.initialLoad = false;
             });
         this.dataView.first = $event.first;
     }
@@ -163,5 +179,9 @@ export class DotThemeSelectorComponent implements OnInit, OnDestroy {
     private filterThemes(searchCriteria?: string): void {
         this.paginatorService.setExtraParams(this.SEARCH_PARAM, searchCriteria);
         this.paginate({ first: 0 });
+    }
+
+    private isSitesWithoutThemes(themes: DotTheme[], $event: LazyLoadEvent): boolean {
+        return this.initialLoad && !themes.length && !$event.first;
     }
 }

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.ts
@@ -110,12 +110,11 @@ export class DotThemeSelectorComponent implements OnInit, OnDestroy {
      * @memberof DotThemeSelectorComponent
      */
     paginate($event: LazyLoadEvent): void {
-        debugger;
         this.paginatorService
             .getWithOffset($event.first)
             .pipe(take(1))
             .subscribe((themes: DotTheme[]) => {
-                if (this.isSitesWithoutThemes(themes, $event)) {
+                if (this.noThemesInInitialLoad(themes, $event)) {
                     this.siteService.getSiteById('SYSTEM_HOST').subscribe((site: Site) => {
                         this.siteSelector.searchableDropdown.handleClick(site);
                         this.cd.detectChanges();
@@ -181,7 +180,7 @@ export class DotThemeSelectorComponent implements OnInit, OnDestroy {
         this.paginate({ first: 0 });
     }
 
-    private isSitesWithoutThemes(themes: DotTheme[], $event: LazyLoadEvent): boolean {
+    private noThemesInInitialLoad(themes: DotTheme[], $event: LazyLoadEvent): boolean {
         return this.initialLoad && !themes.length && !$event.first;
     }
 }

--- a/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
@@ -31,6 +31,7 @@
             width="12.8rem"
             [system]="true"
             (change)="siteChange($event)"
+            data-testId="siteSelector"
         ></dot-site-selector>
         <div class="searchable-dropdown__search-section">
             <dot-icon class="searchable-dropdown__search-icon" name="search"></dot-icon>
@@ -38,7 +39,7 @@
                 data-testId="searchInput"
                 #searchInput
                 pInputText
-                [placeholder]="'search' | dm"
+                [placeholder]="'search' | dm"dot-site-selector
                 type="text"
                 class="searchable-dropdown__search-inputfield"
                 (click)="$event.stopPropagation()"

--- a/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
@@ -39,7 +39,7 @@
                 data-testId="searchInput"
                 #searchInput
                 pInputText
-                [placeholder]="'search' | dm"dot-site-selector
+                [placeholder]="'search' | dm"
                 type="text"
                 class="searchable-dropdown__search-inputfield"
                 (click)="$event.stopPropagation()"

--- a/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
@@ -29,7 +29,7 @@
         <dot-site-selector
             #siteSelector
             width="12.8rem"
-            [id]="id"
+            [system]="true"
             (change)="siteChange($event)"
         ></dot-site-selector>
         <div class="searchable-dropdown__search-section">

--- a/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
@@ -39,6 +39,8 @@ export class DotThemeSelectorDropdownComponent
     @ViewChild('siteSelector')
     siteSelector: DotSiteSelectorComponent;
 
+    private initialLoad = true;
+
     constructor(
         public readonly paginatorService: PaginatorService,
         private readonly siteService: SiteService,
@@ -46,12 +48,7 @@ export class DotThemeSelectorDropdownComponent
     ) {}
 
     ngOnInit(): void {
-        this.siteService
-            .getCurrentSite()
-            .pipe(pluck('identifier'), take(1))
-            .subscribe((identifier: string) => {
-                this.currentSiteIdentifier = identifier;
-            });
+        this.currentSiteIdentifier = this.siteService.currentSite.identifier;
     }
 
     ngAfterViewInit(): void {
@@ -196,8 +193,15 @@ export class DotThemeSelectorDropdownComponent
             .getWithOffset(offset)
             .pipe(take(1))
             .subscribe((themes: DotTheme[]) => {
-                this.themes = themes;
-                this.setTotalRecords();
+                if (themes.length || !this.initialLoad) {
+                    this.themes = themes;
+                    this.setTotalRecords();
+                } else {
+                    this.siteService.getSiteById('SYSTEM_HOST').subscribe((site: Site) => {
+                        this.siteSelector.searchableDropdown.handleClick(site);
+                    });
+                }
+                this.initialLoad = false;
             });
     }
 


### PR DESCRIPTION
Beside the original request: 

Fix: 
- Move between pages not working on site selector. 
- When open the theme selector, the selected site and themes should be the selected by the user and not the current site. 
