### PR TITLE
dotCMS/core#20427 Hide Container/Content controls when inline editing

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.css.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.css.ts
@@ -50,6 +50,10 @@ export const getEditPageCss = (timestampId: string): string => {
         margin-top: 40px !important;
     }
 
+    ${timestampId} [data-dot-object="container"].inline-editing [data-dot-object="contentlet"] .dotedit-contentlet__toolbar {
+        visibility: hidden;
+    }
+
     /*
         When you start D&D in a contentlet dragula clones the elements and append it to the end
         the body and position to the mouse movement. This styles are for that element
@@ -66,7 +70,6 @@ export const getEditPageCss = (timestampId: string): string => {
         z-index: 2147483648 !important;
         pointer-events: none !important;
         user-select: none !important;
-
     }
 
     /*

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/inline-edit-mode.js.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/inline-edit-mode.js.ts
@@ -6,6 +6,7 @@ export const INLINE_TINYMCE_SCRIPTS = `
             const content = ed.getContent();
             const dataset = ed.targetElm.dataset;
             const element = ed.targetElm;
+            const container = ed.bodyElement.closest('[data-dot-object="container"]');
 
             const data = {
                 dataset,
@@ -19,10 +20,12 @@ export const INLINE_TINYMCE_SCRIPTS = `
             // this is the way we can capture the click to init in the editor itself, after the editor 
             // is initialized and clicked we set the pointer-events: auto so users can use the editor as intended.
             if (eventType === "focus" && dataset.mode) {
+                container.classList.add("inline-editing")
                 ed.bodyElement.classList.add("active");
             }
 
             if (eventType === "blur" && ed.bodyElement.classList.contains("active")) {
+                container.classList.remove("inline-editing")
                 ed.bodyElement.classList.remove("active");
             }
 


### PR DESCRIPTION
### Proposed Changes
- Hide the controls in the contentlet when the user is inline editing a field in the contentlet

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
This was achieve with pure CSS.

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
