### PR TITLE
dotCMS/core#20433 fix

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.html
@@ -6,7 +6,7 @@
 <p-multiSelect
     (onChange)="valueChange($event, selectedEnvironments)"
     [(ngModel)]="selectedEnvironments"
-    [options]="pushEnvironments$ | async"
+    [options]="pushEnvironments"
     appendTo="body"
     [defaultLabel]="'contenttypes.content.push_publish.select_environment' | dm"
     optionLabel="name"

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.spec.ts
@@ -132,22 +132,6 @@ describe('PushPublishEnvSelectorComponent', () => {
         expect(comp.selectedEnvironmentIds).toEqual(['12345ab', '6789bc']);
     });
 
-    it('should get environments from PushPublishService', () => {
-        fixture.detectChanges();
-        comp.pushEnvironments$.subscribe((environments) => {
-            expect(environments).toEqual([
-                {
-                    id: '22e332',
-                    name: 'my environment'
-                },
-                {
-                    id: 'joa08',
-                    name: 'my environment 2'
-                }
-            ]);
-        });
-    });
-
     it('should populate the environments if there is just one option', () => {
         const environment = [
             {
@@ -159,6 +143,7 @@ describe('PushPublishEnvSelectorComponent', () => {
         spyOn(comp, 'propagateChange');
         comp.ngOnInit();
         expect(comp.selectedEnvironments).toEqual(environment);
+        expect(comp.pushEnvironments).toEqual(environment);
         expect(comp.propagateChange).toHaveBeenCalled();
     });
 

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input, ViewEncapsulation, forwardRef } from '@angula
 import { PushPublishService } from '@services/push-publish/push-publish.service';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { DotEnvironment } from '@models/dot-environment/dot-environment';
+import { take } from 'rxjs/operators';
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'dot-push-publish-env-selector',
@@ -28,19 +29,22 @@ export class PushPublishEnvSelectorComponent implements OnInit, ControlValueAcce
     constructor(private pushPublishService: PushPublishService) {}
 
     ngOnInit() {
-        this.pushPublishService.getEnvironments().subscribe((environments) => {
-            this.pushEnvironments = environments;
+        this.pushPublishService
+            .getEnvironments()
+            .pipe(take(1))
+            .subscribe((environments) => {
+                this.pushEnvironments = environments;
 
-            if (this.pushPublishService.lastEnvironmentPushed) {
-                this.selectedEnvironments = environments.filter((env) => {
-                    return this.pushPublishService.lastEnvironmentPushed.includes(env.id);
-                });
-                this.valueChange('', this.selectedEnvironments);
-            } else if (environments.length === 1) {
-                this.selectedEnvironments = environments;
-                this.valueChange('', this.selectedEnvironments);
-            }
-        });
+                if (this.pushPublishService.lastEnvironmentPushed) {
+                    this.selectedEnvironments = environments.filter((env) => {
+                        return this.pushPublishService.lastEnvironmentPushed.includes(env.id);
+                    });
+                    this.valueChange('', this.selectedEnvironments);
+                } else if (environments.length === 1) {
+                    this.selectedEnvironments = environments;
+                    this.valueChange('', this.selectedEnvironments);
+                }
+            });
     }
 
     propagateChange = (_: any) => {};

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, Input, ViewEncapsulation, forwardRef } from '@angula
 import { PushPublishService } from '@services/push-publish/push-publish.service';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { DotEnvironment } from '@models/dot-environment/dot-environment';
-import { Observable } from 'rxjs';
 @Component({
     encapsulation: ViewEncapsulation.None,
     selector: 'dot-push-publish-env-selector',
@@ -21,7 +20,7 @@ export class PushPublishEnvSelectorComponent implements OnInit, ControlValueAcce
     assetIdentifier: string;
     @Input()
     showList = false;
-    pushEnvironments$: Observable<any>;
+    pushEnvironments: DotEnvironment[];
     selectedEnvironments: DotEnvironment[];
     selectedEnvironmentIds: string[] = [];
     value: string[];
@@ -29,8 +28,9 @@ export class PushPublishEnvSelectorComponent implements OnInit, ControlValueAcce
     constructor(private pushPublishService: PushPublishService) {}
 
     ngOnInit() {
-        this.pushEnvironments$ = this.pushPublishService.getEnvironments();
         this.pushPublishService.getEnvironments().subscribe((environments) => {
+            this.pushEnvironments = environments;
+
             if (this.pushPublishService.lastEnvironmentPushed) {
                 this.selectedEnvironments = environments.filter((env) => {
                     return this.pushPublishService.lastEnvironmentPushed.includes(env.id);


### PR DESCRIPTION
### Proposed Changes
* After change the component, now we are not listing the selected environments when you try to push something, you need to click in the drop down to see the environments selected. When we open the push modal we are just displaying a Select Environment text and you need to click here to see the list

We need to avoid that extra click, and list the ones that was previously selected in the same component

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![image](https://user-images.githubusercontent.com/37185433/119905085-c58e1a00-bf08-11eb-8e3f-9dfdd1211d9c.png)