### PR TITLE
dotCMS/Core#20550 UI for run the Move subaction 

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
@@ -100,7 +100,6 @@ export class DotCustomEventHandlerService {
     }
 
     private executeWorkflowWizard($event: CustomEvent): void {
-        debugger;
         this.dotWorkflowEventHandlerService.open($event.detail.data);
     }
 }

--- a/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
@@ -100,6 +100,7 @@ export class DotCustomEventHandlerService {
     }
 
     private executeWorkflowWizard($event: CustomEvent): void {
+        debugger;
         this.dotWorkflowEventHandlerService.open($event.detail.data);
     }
 }

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-actions-fire/dot-workflow-actions-fire.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-actions-fire/dot-workflow-actions-fire.service.spec.ts
@@ -22,7 +22,8 @@ const mockBulkOptions: DotActionBulkRequestOptions = {
             publishDate: 'p',
             publishTime: 'pp',
             filterKey: 'f'
-        }
+        },
+        additionalParamsMap: { _path_to_move: '' }
     }
 };
 

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
@@ -54,6 +54,7 @@ const mockWizardSteps: DotWizardStep<any>[] = [
         data: {
             assignable: true,
             commentable: true,
+            moveable: true,
             roleId: mockWorkflowsActions[0].nextAssign,
             roleHierarchy: mockWorkflowsActions[0].roleHierarchyForAssign
         }
@@ -89,10 +90,11 @@ const mockWizardOutputTransformedData = {
     iWantTo: 'publishexpire',
     publishDate: '2020-08-05',
     publishTime: '17-59',
-    whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344'
+    whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344',
+    pathToMove: '/test/'
 };
 
-fdescribe('DotWorkflowEventHandlerService', () => {
+describe('DotWorkflowEventHandlerService', () => {
     let dotWorkflowEventHandlerService: DotWorkflowEventHandlerService;
     let dotWizardService: DotWizardService;
     let dotWorkflowActionsFireService: DotWorkflowActionsFireService;

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
@@ -91,7 +91,7 @@ const mockWizardOutputTransformedData = {
     whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344'
 };
 
-fdescribe('DotWorkflowEventHandlerService', () => {
+describe('DotWorkflowEventHandlerService', () => {
     let dotWorkflowEventHandlerService: DotWorkflowEventHandlerService;
     let dotWizardService: DotWizardService;
     let dotWorkflowActionsFireService: DotWorkflowActionsFireService;

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
@@ -73,7 +73,7 @@ const mockWizardInput: DotWizardInput = {
 const mockWizardOutputData = {
     assign: '654b0931-1027-41f7-ad4d-173115ed8ec1',
     comments: 'ds',
-    move: '/test/',
+    pathToMove: '/test/',
     environment: ['37fe23d5-588d-4c61-a9ea-70d01e913344'],
     expireDate: '2020-08-11 19:59',
     filterKey: 'Intelligent.yml',
@@ -219,7 +219,7 @@ describe('DotWorkflowEventHandlerService', () => {
                         publishTime: '17-59',
                         filterKey: 'Intelligent.yml'
                     },
-                    additionalParamsMap: { _path_to_move: mockWizardOutputData.move }
+                    additionalParamsMap: { _path_to_move: mockWizardOutputData.pathToMove }
                 },
                 query: 'query'
             };

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
@@ -91,7 +91,7 @@ const mockWizardOutputTransformedData = {
     whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344'
 };
 
-describe('DotWorkflowEventHandlerService', () => {
+fdescribe('DotWorkflowEventHandlerService', () => {
     let dotWorkflowEventHandlerService: DotWorkflowEventHandlerService;
     let dotWizardService: DotWizardService;
     let dotWorkflowActionsFireService: DotWorkflowActionsFireService;
@@ -215,7 +215,8 @@ describe('DotWorkflowEventHandlerService', () => {
                         publishDate: '2020-08-05',
                         publishTime: '17-59',
                         filterKey: 'Intelligent.yml'
-                    }
+                    },
+                    additionalParamsMap: { _path_to_move: '' }
                 },
                 query: 'query'
             };

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
@@ -72,6 +72,7 @@ const mockWizardInput: DotWizardInput = {
 const mockWizardOutputData = {
     assign: '654b0931-1027-41f7-ad4d-173115ed8ec1',
     comments: 'ds',
+    move: '/test/',
     environment: ['37fe23d5-588d-4c61-a9ea-70d01e913344'],
     expireDate: '2020-08-11 19:59',
     filterKey: 'Intelligent.yml',
@@ -91,7 +92,7 @@ const mockWizardOutputTransformedData = {
     whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344'
 };
 
-describe('DotWorkflowEventHandlerService', () => {
+fdescribe('DotWorkflowEventHandlerService', () => {
     let dotWorkflowEventHandlerService: DotWorkflowEventHandlerService;
     let dotWizardService: DotWizardService;
     let dotWorkflowActionsFireService: DotWorkflowActionsFireService;
@@ -204,8 +205,8 @@ describe('DotWorkflowEventHandlerService', () => {
                 workflowActionId: '44d4d4cd-c812-49db-adb1-1030be73e69a',
                 additionalParams: {
                     assignComment: {
-                        comment: 'ds',
-                        assign: '654b0931-1027-41f7-ad4d-173115ed8ec1'
+                        comment: mockWizardOutputData.comments,
+                        assign: mockWizardOutputData.assign
                     },
                     pushPublish: {
                         whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344',
@@ -216,7 +217,7 @@ describe('DotWorkflowEventHandlerService', () => {
                         publishTime: '17-59',
                         filterKey: 'Intelligent.yml'
                     },
-                    additionalParamsMap: { _path_to_move: '' }
+                    additionalParamsMap: { _path_to_move: mockWizardOutputData.move }
                 },
                 query: 'query'
             };

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
@@ -153,6 +153,8 @@ export class DotWorkflowEventHandlerService {
             delete data.environment;
             delete data.pushActionSelected;
         }
+        data['pathToMove'] = data.move;
+        delete data.move;
         return data;
     }
 

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
@@ -194,6 +194,7 @@ export class DotWorkflowEventHandlerService {
         data?: { [key: string]: any }
     ): void {
         if (this.isBulkAction(event)) {
+
             this.dotIframeService.run({ name: 'fireActionLoadingIndicator' });
             this.dotWorkflowActionsFireService
                 .bulkFire(this.processBulkData(event, data))
@@ -281,7 +282,7 @@ export class DotWorkflowEventHandlerService {
                     publishTime: data.publishTime,
                     filterKey: data.filterKey
                 },
-                additionalParamsMap: { _path_to_move: data.move }
+                additionalParamsMap: { _path_to_move: data.pathToMove }
             }
         };
         if (Array.isArray(event.selectedInodes)) {

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
@@ -282,7 +282,7 @@ export class DotWorkflowEventHandlerService {
                     publishTime: data.publishTime,
                     filterKey: data.filterKey
                 },
-                additionalBeanMap: { _path_to_move: data.move }
+                additionalParamsMap: { _path_to_move: data.move }
             }
         };
         if (Array.isArray(event.selectedInodes)) {

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
@@ -27,7 +27,8 @@ import { DotActionBulkRequestOptions } from '@models/dot-action-bulk-request-opt
 enum DotActionInputs {
     ASSIGNABLE = 'assignable',
     COMMENTABLE = 'commentable',
-    COMMENTANDASSIGN = 'commentAndAssign'
+    COMMENTANDASSIGN = 'commentAndAssign',
+    MOVEABLE = 'moveable'
 }
 
 const EDIT_CONTENT_CALLBACK_FUNCTION = 'saveAssignCallBackAngular';
@@ -115,6 +116,7 @@ export class DotWorkflowEventHandlerService {
      */
     setWizardInput(workflow: DotCMSWorkflowAction, title: string): DotWizardInput {
         const steps: DotWizardStep<any>[] = [];
+        debugger;
         this.mergeCommentAndAssign(workflow).forEach((input: DotCMSWorkflowInput) => {
             if (this.workflowStepMap[input.id]) {
                 steps.push({
@@ -157,6 +159,7 @@ export class DotWorkflowEventHandlerService {
 
     private mergeCommentAndAssign(workflow: DotCMSWorkflowAction): DotCMSWorkflowInput[] {
         const body = {};
+        debugger;
         let workflows: DotCMSWorkflowInput[];
         workflow.actionInputs.forEach((input) => {
             if (this.isCommentOrAssign(input.id)) {
@@ -182,6 +185,7 @@ export class DotWorkflowEventHandlerService {
             )
             .pipe(take(1))
             .subscribe((data: { [key: string]: any }) => {
+                debugger;
                 this.fireWorkflowAction(event, data);
             });
     }
@@ -250,7 +254,11 @@ export class DotWorkflowEventHandlerService {
     }
 
     private isCommentOrAssign(id: string): boolean {
-        return id === DotActionInputs.ASSIGNABLE || id === DotActionInputs.COMMENTABLE;
+        return (
+            id === DotActionInputs.ASSIGNABLE ||
+            id === DotActionInputs.COMMENTABLE ||
+            id === DotActionInputs.MOVEABLE
+        );
     }
 
     private processBulkData(
@@ -273,7 +281,8 @@ export class DotWorkflowEventHandlerService {
                     publishDate: data.publishDate,
                     publishTime: data.publishTime,
                     filterKey: data.filterKey
-                }
+                },
+                additionalBeanMap: { _path_to_move: data.move }
             }
         };
         if (Array.isArray(event.selectedInodes)) {

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
@@ -153,8 +153,6 @@ export class DotWorkflowEventHandlerService {
             delete data.environment;
             delete data.pushActionSelected;
         }
-        data['pathToMove'] = data.move;
-        delete data.move;
         return data;
     }
 
@@ -194,7 +192,6 @@ export class DotWorkflowEventHandlerService {
         data?: { [key: string]: any }
     ): void {
         if (this.isBulkAction(event)) {
-
             this.dotIframeService.run({ name: 'fireActionLoadingIndicator' });
             this.dotWorkflowActionsFireService
                 .bulkFire(this.processBulkData(event, data))

--- a/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
@@ -116,7 +116,6 @@ export class DotWorkflowEventHandlerService {
      */
     setWizardInput(workflow: DotCMSWorkflowAction, title: string): DotWizardInput {
         const steps: DotWizardStep<any>[] = [];
-        debugger;
         this.mergeCommentAndAssign(workflow).forEach((input: DotCMSWorkflowInput) => {
             if (this.workflowStepMap[input.id]) {
                 steps.push({
@@ -159,15 +158,14 @@ export class DotWorkflowEventHandlerService {
 
     private mergeCommentAndAssign(workflow: DotCMSWorkflowAction): DotCMSWorkflowInput[] {
         const body = {};
-        debugger;
         let workflows: DotCMSWorkflowInput[];
         workflow.actionInputs.forEach((input) => {
-            if (this.isCommentOrAssign(input.id)) {
+            if (this.isValidActionInput(input.id)) {
                 body[input.id] = true;
             }
         });
         if (Object.keys(body).length) {
-            workflows = workflow.actionInputs.filter((input) => !this.isCommentOrAssign(input.id));
+            workflows = workflow.actionInputs.filter((input) => !this.isValidActionInput(input.id));
             workflows.unshift({
                 id: DotActionInputs.COMMENTANDASSIGN,
                 body: { ...body, ...this.getAssignableData(workflow) }
@@ -185,7 +183,6 @@ export class DotWorkflowEventHandlerService {
             )
             .pipe(take(1))
             .subscribe((data: { [key: string]: any }) => {
-                debugger;
                 this.fireWorkflowAction(event, data);
             });
     }
@@ -253,7 +250,7 @@ export class DotWorkflowEventHandlerService {
         return { roleId: workflow.nextAssign, roleHierarchy: workflow.roleHierarchyForAssign };
     }
 
-    private isCommentOrAssign(id: string): boolean {
+    private isValidActionInput(id: string): boolean {
         return (
             id === DotActionInputs.ASSIGNABLE ||
             id === DotActionInputs.COMMENTABLE ||

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.spec.ts
@@ -199,7 +199,7 @@ describe('DotEditPageWorkflowsActionsComponent', () => {
                     const mockData = {
                         assign: '654b0931-1027-41f7-ad4d-173115ed8ec1',
                         comments: 'ds',
-                        move: '/test/',
+                        pathToMove: '/test/',
                         environment: ['37fe23d5-588d-4c61-a9ea-70d01e913344'],
                         expireDate: '2020-08-11 19:59',
                         filterKey: 'Intelligent.yml',

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.spec.ts
@@ -43,6 +43,7 @@ import { DotWorkflowEventHandlerService } from '@services/dot-workflow-event-han
 import { DotIframeService } from '@components/_common/iframe/service/dot-iframe/dot-iframe.service';
 import { Menu, MenuModule } from 'primeng/menu';
 import { ConfirmationService } from 'primeng/api';
+import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-icon-button.module';
 
 @Component({
     selector: 'dot-test-host-component',
@@ -76,7 +77,8 @@ describe('DotEditPageWorkflowsActionsComponent', () => {
                 RouterTestingModule,
                 BrowserAnimationsModule,
                 MenuModule,
-                HttpClientTestingModule
+                HttpClientTestingModule,
+                UiDotIconButtonModule
             ],
             declarations: [DotEditPageWorkflowsActionsComponent, TestHostComponent],
             providers: [
@@ -197,6 +199,7 @@ describe('DotEditPageWorkflowsActionsComponent', () => {
                     const mockData = {
                         assign: '654b0931-1027-41f7-ad4d-173115ed8ec1',
                         comments: 'ds',
+                        move: '/test/',
                         environment: ['37fe23d5-588d-4c61-a9ea-70d01e913344'],
                         expireDate: '2020-08-11 19:59',
                         filterKey: 'Intelligent.yml',
@@ -213,7 +216,8 @@ describe('DotEditPageWorkflowsActionsComponent', () => {
                         iWantTo: 'publishexpire',
                         publishDate: '2020-08-05',
                         publishTime: '17-59',
-                        whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344'
+                        whereToSend: '37fe23d5-588d-4c61-a9ea-70d01e913344',
+                        pathToMove: '/test/'
                     };
 
                     let dotWizardService: DotWizardService;
@@ -289,7 +293,7 @@ describe('DotEditPageWorkflowsActionsComponent', () => {
 
                 it('should refresh the action list after fire action', () => {
                     secondButton.click();
-                    expect(dotWorkflowsActionsService.getByInode).toHaveBeenCalledTimes(1);
+                    expect(dotWorkflowsActionsService.getByInode).toHaveBeenCalledTimes(2); // initial ngOnChanges & action.
                 });
 
                 it('should emit event after action was fired', () => {

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -104,7 +104,6 @@
         <dot-page-selector
             id="content-type-form-detail-page"
             formControlName="detailPage"
-            [floatingLabel]="true"
             [tabindex]="7"
             [label]="'contenttypes.form.field.detail.page' | dm"
         ></dot-page-selector>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
@@ -645,7 +645,6 @@ describe('ContentTypesFormComponent', () => {
         const pageSelector: DebugElement = de.query(By.css('dot-page-selector'));
         expect(pageSelector !== null).toBe(true);
         expect(pageSelector.componentInstance.label).toEqual('Detail Page');
-        expect(pageSelector.componentInstance.floatingLabel).toBe(true);
     });
 
     describe('send data with valid form', () => {

--- a/apps/dotcms-ui/src/app/shared/models/dot-action-bulk-request-options/dot-action-bulk-request-options.model.ts
+++ b/apps/dotcms-ui/src/app/shared/models/dot-action-bulk-request-options/dot-action-bulk-request-options.model.ts
@@ -21,5 +21,6 @@ export interface DotActionBulkRequestOptions {
             publishTime: string;
             filterKey: string;
         };
+        additionalBeanMap: { _path_to_move: string };
     };
 }

--- a/apps/dotcms-ui/src/app/shared/models/dot-action-bulk-request-options/dot-action-bulk-request-options.model.ts
+++ b/apps/dotcms-ui/src/app/shared/models/dot-action-bulk-request-options/dot-action-bulk-request-options.model.ts
@@ -21,6 +21,6 @@ export interface DotActionBulkRequestOptions {
             publishTime: string;
             filterKey: string;
         };
-        additionalBeanMap: { _path_to_move: string };
+        additionalParamsMap: { _path_to_move: string };
     };
 }

--- a/apps/dotcms-ui/src/app/test/dot-workflows-actions.mock.ts
+++ b/apps/dotcms-ui/src/app/test/dot-workflows-actions.mock.ts
@@ -28,7 +28,8 @@ export const mockWorkflowsActions: DotCMSWorkflowAction[] = [
             {
                 body: {},
                 id: 'pushPublish'
-            }
+            },
+            { body: {}, id: 'moveable' }
         ]
     },
     {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
@@ -1,64 +1,34 @@
 <div class="p-field">
     <label class="form__label">{{ label }}</label>
-    <span *ngIf="floatingLabel; else placeholded">
-        <p-autoComplete
-            #autoComplete
-            appendTo="body"
-            (completeMethod)="search($event)"
-            (keydown.enter)="onKeyEnter($event)"
-            (keydown.tab)="$event.preventDefault()"
-            (onClear)="onClear()"
-            (onSelect)="onSelect($event)"
-            [minLength]="2"
-            field="label"
-            [ngModel]="val"
-            [suggestions]="suggestions$ | async"
-            [placeholder]=" 'page.selector.placeholder' | dm"
-        >
-            <ng-template let-item pTemplate="item">
-                <div class="dot-page-selector__item">
-                    <span *ngIf="searchType === 'site'; else notSite" >{{ item.label }}</span>
-                    <ng-template #notSite>
-                        <span class="dot-page-selector__item-url">
-                            {{ item.payload.path }}
-                        </span>
-                        <span class="dot-page-selector__item-host">
-                            {{item.payload.hostname}}
-                        </span>
-                    </ng-template>
-                </div>
-            </ng-template>
-        </p-autoComplete>
-    </span>
-    <small [class]=" isError ? 'p-invalid' : 'p-info'" [textContent]="message"></small>
-    <dot-field-helper [message]=" (folderSearch ? 'page.selector.folder.hint' : 'page.selector.hint') | dm"></dot-field-helper>
-</div>
-
-<ng-template #placeholded>
     <p-autoComplete
+        #autoComplete
         appendTo="body"
+        data-testId="p-autoComplete"
         (completeMethod)="search($event)"
         (keydown.enter)="onKeyEnter($event)"
         (keydown.tab)="$event.preventDefault()"
         (onClear)="onClear()"
         (onSelect)="onSelect($event)"
-        [minLength]="3"
+        [minLength]="2"
         field="label"
         [ngModel]="val"
         [suggestions]="suggestions$ | async"
+        [placeholder]=" 'page.selector.placeholder' | dm"
     >
         <ng-template let-item pTemplate="item">
             <div class="dot-page-selector__item">
                 <span *ngIf="searchType === 'site'; else notSite" >{{ item.label }}</span>
                 <ng-template #notSite>
-                        <span class="dot-page-selector__item-url">
-                            {{ item.payload.path }}
-                        </span>
+                    <span class="dot-page-selector__item-url">
+                        {{ item.payload.path }}
+                    </span>
                     <span class="dot-page-selector__item-host">
-                            {{item.payload.hostname}}
-                        </span>
+                        {{item.payload.hostName}}
+                    </span>
                 </ng-template>
             </div>
         </ng-template>
     </p-autoComplete>
-</ng-template>
+    <small data-testId="message" [class]=" isError ? 'p-invalid' : 'p-info'" [textContent]="message"></small>
+    <dot-field-helper [message]=" (folderSearch ? 'page.selector.folder.hint' : 'page.selector.hint') | dm"></dot-field-helper>
+</div>

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
@@ -1,7 +1,8 @@
 <div class="p-field">
-    <label>{{ label }}</label>
+    <label class="form__label">{{ label }}</label>
     <span *ngIf="floatingLabel; else placeholded">
         <p-autoComplete
+            #autoComplete
             appendTo="body"
             (completeMethod)="search($event)"
             (keydown.enter)="onKeyEnter($event)"
@@ -11,19 +12,18 @@
             [minLength]="2"
             field="label"
             [ngModel]="val"
-            [suggestions]="results.data"
+            [suggestions]="suggestions | async"
         >
             <ng-template let-item pTemplate="item">
                 <div class="dot-page-selector__item">
-                    <span *ngIf="results.type === 'site'">{{ item.label }}</span>
+                    <span *ngIf="searchType === 'site'">{{ item.label }}</span>
                     <span
                         class="dot-page-selector__item-url"
-                        *ngIf="results.type === 'page'"
-                        style=""
+                        *ngIf="searchType !== 'site'"
                         >{{ item.payload.path }}</span
                     >
-                    <span class="dot-page-selector__item-host" *ngIf="results.type === 'page'">{{
-                        item.payload.hostName
+                    <span class="dot-page-selector__item-host" *ngIf="searchType !== 'site'">{{
+                        item.payload.hostname
                     }}</span>
                 </div>
             </ng-template>
@@ -34,31 +34,5 @@
 </div>
 
 <ng-template #placeholded>
-    <p-autoComplete
-        appendTo="body"
-        (completeMethod)="search($event)"
-        (keydown.enter)="onKeyEnter($event)"
-        (keydown.tab)="$event.preventDefault()"
-        (onClear)="onClear($event)"
-        (onSelect)="onSelect($event)"
-        [minLength]="3"
-        field="label"
-        [ngModel]="val"
-        [suggestions]="results.data"
-    >
-        <ng-template let-item pTemplate="item">
-            <div class="dot-page-selector__item">
-                <span *ngIf="results.type === 'site'">{{ item.label }}</span>
-                <span
-                    class="dot-page-selector__item-url"
-                    *ngIf="results.type === 'page'"
-                    style=""
-                    >{{ item.payload.path }}</span
-                >
-                <span class="dot-page-selector__item-host" *ngIf="results.type === 'page'">{{
-                    item.payload.hostName
-                }}</span>
-            </div>
-        </ng-template>
-    </p-autoComplete>
+
 </ng-template>

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
@@ -7,7 +7,7 @@
             (completeMethod)="search($event)"
             (keydown.enter)="onKeyEnter($event)"
             (keydown.tab)="$event.preventDefault()"
-            (onClear)="onClear($event)"
+            (onClear)="onClear()"
             (onSelect)="onSelect($event)"
             [minLength]="2"
             field="label"
@@ -29,7 +29,7 @@
             </ng-template>
         </p-autoComplete>
     </span>
-    <small *ngIf="message" class="p-invalid" [textContent]="message"></small>
+    <small *ngIf="emptyMessage" class="p-invalid" [textContent]="emptyMessage"></small>
     <dot-field-helper [message]="'page.selector.hint' | dm"></dot-field-helper>
 </div>
 

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
@@ -12,20 +12,20 @@
             [minLength]="2"
             field="label"
             [ngModel]="val"
-            [suggestions]="suggestions | async"
+            [suggestions]="suggestions$ | async"
             [placeholder]=" 'page.selector.placeholder' | dm"
         >
             <ng-template let-item pTemplate="item">
                 <div class="dot-page-selector__item">
-                    <span *ngIf="searchType === 'site'">{{ item.label }}</span>
-                    <span
-                        class="dot-page-selector__item-url"
-                        *ngIf="searchType !== 'site'"
-                        >{{ item.payload.path }}</span
-                    >
-                    <span class="dot-page-selector__item-host" *ngIf="searchType !== 'site'">{{
-                        item.payload.hostname
-                    }}</span>
+                    <span *ngIf="searchType === 'site'; else notSite" >{{ item.label }}</span>
+                    <ng-template #notSite>
+                        <span class="dot-page-selector__item-url">
+                            {{ item.payload.path }}
+                        </span>
+                        <span class="dot-page-selector__item-host">
+                            {{item.payload.hostname}}
+                        </span>
+                    </ng-template>
                 </div>
             </ng-template>
         </p-autoComplete>
@@ -45,19 +45,19 @@
         [minLength]="3"
         field="label"
         [ngModel]="val"
-        [suggestions]="suggestions | async"
+        [suggestions]="suggestions$ | async"
     >
         <ng-template let-item pTemplate="item">
             <div class="dot-page-selector__item">
-                <span *ngIf="searchType === 'site'">{{ item.label }}</span>
-                <span
-                    class="dot-page-selector__item-url"
-                    *ngIf="searchType !== 'site'"
-                >{{ item.payload.path }}</span
-                >
-                <span class="dot-page-selector__item-host" *ngIf="searchType !== 'site'">{{
-                    item.payload.hostname
-                    }}</span>
+                <span *ngIf="searchType === 'site'; else notSite" >{{ item.label }}</span>
+                <ng-template #notSite>
+                        <span class="dot-page-selector__item-url">
+                            {{ item.payload.path }}
+                        </span>
+                    <span class="dot-page-selector__item-host">
+                            {{item.payload.hostname}}
+                        </span>
+                </ng-template>
             </div>
         </ng-template>
     </p-autoComplete>

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
@@ -13,6 +13,7 @@
             field="label"
             [ngModel]="val"
             [suggestions]="suggestions | async"
+            [placeholder]=" 'page.selector.placeholder' | dm"
         >
             <ng-template let-item pTemplate="item">
                 <div class="dot-page-selector__item">
@@ -29,8 +30,8 @@
             </ng-template>
         </p-autoComplete>
     </span>
-    <small *ngIf="emptyMessage" class="p-invalid" [textContent]="emptyMessage"></small>
-    <dot-field-helper [message]="'page.selector.hint' | dm"></dot-field-helper>
+    <small [class]=" isError ? 'p-invalid' : 'p-info'" [textContent]="message"></small>
+    <dot-field-helper [message]=" (folderSearch ? 'page.selector.folder.hint' : 'page.selector.hint') | dm"></dot-field-helper>
 </div>
 
 <ng-template #placeholded>

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
@@ -34,5 +34,30 @@
 </div>
 
 <ng-template #placeholded>
-
+    <p-autoComplete
+        appendTo="body"
+        (completeMethod)="search($event)"
+        (keydown.enter)="onKeyEnter($event)"
+        (keydown.tab)="$event.preventDefault()"
+        (onClear)="onClear()"
+        (onSelect)="onSelect($event)"
+        [minLength]="3"
+        field="label"
+        [ngModel]="val"
+        [suggestions]="suggestions | async"
+    >
+        <ng-template let-item pTemplate="item">
+            <div class="dot-page-selector__item">
+                <span *ngIf="searchType === 'site'">{{ item.label }}</span>
+                <span
+                    class="dot-page-selector__item-url"
+                    *ngIf="searchType !== 'site'"
+                >{{ item.payload.path }}</span
+                >
+                <span class="dot-page-selector__item-host" *ngIf="searchType !== 'site'">{{
+                    item.payload.hostname
+                    }}</span>
+            </div>
+        </ng-template>
+    </p-autoComplete>
 </ng-template>

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.scss
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.scss
@@ -23,6 +23,10 @@
     dot-field-helper {
         @include dot-field-helper-on-input;
     }
+
+    .p-info{
+        color: $info;
+    }
 }
 
 .dot-page-selector__item {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
@@ -1,300 +1,300 @@
-import { of as observableOf, Observable } from 'rxjs';
-import { waitForAsync, ComponentFixture } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement, Component, Injectable } from '@angular/core';
-
-import { DotPageSelectorComponent } from './dot-page-selector.component';
-import { DOTTestBed } from '../../../../test/dot-test-bed';
-import { DotPageSelectorService } from './service/dot-page-selector.service';
-import { FormGroup, FormBuilder } from '@angular/forms';
-import { AutoComplete } from 'primeng/autocomplete';
-import { DotDirectivesModule } from '@shared/dot-directives.module';
-import {
-    DotPageSelectorResults,
-    DotPageSelectorItem
-} from '@components/_common/dot-page-selector/models/dot-page-selector.models';
-import { LoginService } from '@dotcms/dotcms-js';
-import { LoginServiceMock } from '../../../../test/login-service.mock';
-import { DotFieldHelperModule } from '@components/dot-field-helper/dot-field-helper.module';
-import { DotMessageService } from '@services/dot-message/dot-messages.service';
-import { MockDotMessageService } from '@tests/dot-message-service.mock';
-import { Site } from '@dotcms/dotcms-js';
-
-export const mockDotPageSelectorResults = {
-    type: 'page',
-    query: 'about-us',
-    data: [
-        {
-            label: '//demo.dotcms.com/about-us',
-            payload: {
-                template: '8660b482-1ef6-4d00-9459-3996e703ba19',
-                owner: 'dotcms.org.1',
-                identifier: 'c12fe7e6-d338-49d5-973b-2d974d57015b',
-                friendlyname: 'About Us',
-                modDate: '2018-05-21 09:52:38.461',
-                cachettl: '0',
-                pagemetadata: 'dotCMS',
-                languageId: 1,
-                title: 'About Us',
-                showOnMenu: 'true',
-                inode: '5cd3b647-e465-4a6d-a78b-e834a7a7331a',
-                seodescription: 'dotCMS Content Management System demo site - About Quest',
-                folder: '1049e7fe-1553-4731-bdf9-ba069f1dc08b',
-                __DOTNAME__: 'About Us',
-                sortOrder: 0,
-                path: '/about-us',
-                seokeywords: 'dotCMS Content Management System',
-                modUser: 'dotcms.org.1',
-                host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
-                lastReview: '2018-05-18 15:30:34.428',
-                stInode: 'c541abb1-69b3-4bc5-8430-5e09e5239cc8',
-                url: '/about-us/index',
-                hostName: 'demo.dotcms.com'
-            }
-        }
-    ]
-};
-
-export const mockDotSiteSelectorResults = {
-    type: 'site',
-    query: 'demo.dotcms.com',
-    data: [
-        {
-            label: '//demo.dotcms.com/',
-            isHost: true,
-            payload: {
-                hostname: 'demo.dotcms.com',
-                type: 'host',
-                identifier: 's48190c8c-42c4-46af-8d1a-0cd5db894797',
-                archived: false
-            }
-        }
-    ]
-};
-
-@Injectable()
-class MockDotPageSelectorService {
-    search(_param: string): Observable<DotPageSelectorResults> {
-        return observableOf(mockDotPageSelectorResults);
-    }
-
-    setCurrentHost(_site: Site) {}
-
-    getPageById(_param: string): Observable<DotPageSelectorItem> {
-        return observableOf(mockDotPageSelectorResults.data[0]);
-    }
-}
-@Component({
-    selector: 'dot-fake-form',
-    template: `
-        <form [formGroup]="form">
-            <dot-page-selector
-                [floatingLabel]="floatingLabel"
-                formControlName="page"
-                [style]="{ width: '100%' }"
-                label="Hello World"
-            >
-            </dot-page-selector>
-        </form>
-    `
-})
-class FakeFormComponent {
-    form: FormGroup;
-    floatingLabel = false;
-
-    constructor(private fb: FormBuilder) {
-        /*
-            This should go in the ngOnInit but I don't want to detectChanges everytime for
-            this fake test component
-        */
-        this.form = this.fb.group({
-            page: [{ value: 'c12fe7e6-d338-49d5-973b-2d974d57015b', disabled: false }]
-        });
-    }
-}
-
-const messageServiceMock = new MockDotMessageService({
-    'page.selector.no.sites.results': 'Search for sites have no results',
-    'page.selector.no.page.results': 'Search for pages have no results'
-});
-
-const config = (host) => {
-    return {
-        declarations: [host, DotPageSelectorComponent],
-        imports: [DotDirectivesModule, DotFieldHelperModule],
-        providers: [
-            { provide: DotPageSelectorService, useClass: MockDotPageSelectorService },
-            { provide: LoginService, useClass: LoginServiceMock },
-            { provide: DotMessageService, useValue: messageServiceMock }
-        ]
-    };
-};
-let hostDe: DebugElement;
-let component: DotPageSelectorComponent;
-let de: DebugElement;
-let autocomplete: DebugElement;
-let autocompleteComp: AutoComplete;
-let dotPageSelectorService: DotPageSelectorService;
-
-describe('DotPageSelectorComponent', () => {
-    let hostFixture: ComponentFixture<FakeFormComponent>;
-    const searchPageObj = { originalEvent: { target: { value: 'demo' } }, query: 'demo' };
-    const invalidSearchPageObj = { originalEvent: { target: { value: 'de' } }, query: 'de' };
-    const searchHostObj = { originalEvent: { target: { value: '//' } }, query: '//' };
-    const specialSearchObj = { originalEvent: { target: { value: 'd#emo$%' } }, query: 'd#emo$%' };
-
-    beforeEach(
-        waitForAsync(() => {
-            DOTTestBed.configureTestingModule(config(FakeFormComponent));
-        })
-    );
-
-    beforeEach(async () => {
-        hostFixture = DOTTestBed.createComponent(FakeFormComponent);
-        hostDe = hostFixture.debugElement;
-        de = hostDe.query(By.css('dot-page-selector'));
-        component = de.componentInstance;
-        dotPageSelectorService = de.injector.get(DotPageSelectorService);
-
-        spyOn(component.selected, 'emit');
-        spyOn(component, 'writeValue').and.callThrough();
-
-        hostFixture.detectChanges();
-        await hostFixture.whenStable();
-        autocomplete = de.query(By.css('p-autoComplete'));
-        autocompleteComp = autocomplete.componentInstance;
-    });
-
-    it('should have autocomplete', () => {
-        expect(autocomplete).toBeTruthy();
-    });
-
-    it('shold not set floating label directive', () => {
-        expect(de.query(By.css('[dotMdInputtext]')) === null).toBe(true);
-    });
-
-    it('should search for pages', () => {
-        spyOn(dotPageSelectorService, 'search').and.returnValue(
-            observableOf({ ...mockDotSiteSelectorResults })
-        );
-        autocomplete.triggerEventHandler('completeMethod', searchPageObj);
-        expect(dotPageSelectorService.search).toHaveBeenCalledWith(searchPageObj.query);
-    });
-
-    it('should not search for pages if has less than 3 characters', () => {
-        component.results = Object.assign({}, mockDotSiteSelectorResults);
-        spyOn(dotPageSelectorService, 'search').and.returnValue(observableOf(null));
-        autocomplete.triggerEventHandler('completeMethod', invalidSearchPageObj);
-
-        expect(dotPageSelectorService.search).not.toHaveBeenCalled();
-        expect(component.results.data.length).toBe(0);
-    });
-
-    it('should search for host', () => {
-        spyOn(dotPageSelectorService, 'search').and.returnValue(
-            observableOf({ ...mockDotSiteSelectorResults })
-        );
-        autocomplete.triggerEventHandler('completeMethod', searchHostObj);
-        expect(dotPageSelectorService.search).toHaveBeenCalledWith(searchHostObj.query);
-    });
-
-    it('should set current host on selection', () => {
-        component.results = mockDotSiteSelectorResults;
-        spyOn<any>(dotPageSelectorService, 'setCurrentHost').and.returnValue(observableOf(null));
-        autocomplete.triggerEventHandler('onSelect', mockDotSiteSelectorResults.data[0]);
-        expect(dotPageSelectorService.setCurrentHost).toHaveBeenCalledWith(
-            mockDotSiteSelectorResults.data[0].payload
-        );
-    });
-
-    it('should remove special characters when searching for pages', () => {
-        spyOn(dotPageSelectorService, 'search').and.returnValue(
-            observableOf({ ...mockDotSiteSelectorResults })
-        );
-        autocomplete.triggerEventHandler('completeMethod', specialSearchObj);
-        expect(dotPageSelectorService.search).toHaveBeenCalledWith('demo');
-    });
-
-    it('should display error when no results in pages', () => {
-        spyOn(dotPageSelectorService, 'search').and.returnValue(
-            observableOf({
-                type: 'page',
-                query: 'invalid',
-                data: []
-            })
-        );
-        autocomplete.triggerEventHandler('completeMethod', {
-            originalEvent: { target: { value: 'invalidPage' } },
-            query: 'invalidPage'
-        });
-
-        expect(component.message).toEqual('Search for pages have no results');
-    });
-
-    it('should display error when no results in hosts', () => {
-        spyOn(dotPageSelectorService, 'search').and.returnValue(
-            observableOf({
-                type: 'site',
-                query: 'invalid',
-                data: []
-            })
-        );
-        autocomplete.triggerEventHandler('completeMethod', {
-            originalEvent: { target: { value: '//invalid' } },
-            query: '//invalid'
-        });
-
-        expect(component.message).toEqual('Search for sites have no results');
-    });
-
-    describe('ControlValueAccessor', () => {
-        beforeEach(() => {
-            spyOn(component, 'propagateChange').and.callThrough();
-        });
-
-        it('should emit selected item and propagate changes', () => {
-            component.results = mockDotPageSelectorResults;
-            autocomplete.triggerEventHandler('onSelect', mockDotPageSelectorResults.data[0]);
-            expect(component.selected.emit).toHaveBeenCalledWith(
-                mockDotPageSelectorResults.data[0].payload
-            );
-            expect(component.propagateChange).toHaveBeenCalledWith(
-                mockDotPageSelectorResults.data[0].payload.identifier
-            );
-        });
-
-        it('should write value', () => {
-            expect(component.writeValue).toHaveBeenCalledWith(
-                'c12fe7e6-d338-49d5-973b-2d974d57015b'
-            );
-            expect(component.val.payload.identifier).toEqual(
-                'c12fe7e6-d338-49d5-973b-2d974d57015b'
-            );
-        });
-
-        it('should clear model and suggections', () => {
-            autocomplete.triggerEventHandler('onClear', {});
-            expect(component.propagateChange).toHaveBeenCalledWith(null);
-            expect(component.results.data).toEqual([]);
-        });
-    });
-
-    describe('floating label', () => {
-        beforeEach(() => {
-            component.floatingLabel = true;
-            hostFixture.detectChanges();
-            autocomplete = de.query(By.css('p-autoComplete'));
-            autocompleteComp = autocomplete.componentInstance;
-        });
-
-        it('should set floating label directive', () => {
-            const span: DebugElement = de.query(By.css('.p-field'));
-            expect(span.componentInstance.label).toBe('Hello World');
-            expect(span).toBeTruthy();
-        });
-
-        it('should not have placeholder', () => {
-            expect(autocompleteComp.placeholder).toBeUndefined();
-        });
-    });
-});
+// import { of as observableOf, Observable } from 'rxjs';
+// import { waitForAsync, ComponentFixture } from '@angular/core/testing';
+// import { By } from '@angular/platform-browser';
+// import { DebugElement, Component, Injectable } from '@angular/core';
+//
+// import { DotPageSelectorComponent } from './dot-page-selector.component';
+// import { DOTTestBed } from '../../../../test/dot-test-bed';
+// import { DotPageSelectorService } from './service/dot-page-selector.service';
+// import { FormGroup, FormBuilder } from '@angular/forms';
+// import { AutoComplete } from 'primeng/autocomplete';
+// import { DotDirectivesModule } from '@shared/dot-directives.module';
+// import {
+//     DotPageSelectorResults,
+//     DotPageSelectorItem
+// } from '@components/_common/dot-page-selector/models/dot-page-selector.models';
+// import { LoginService } from '@dotcms/dotcms-js';
+// import { LoginServiceMock } from '../../../../test/login-service.mock';
+// import { DotFieldHelperModule } from '@components/dot-field-helper/dot-field-helper.module';
+// import { DotMessageService } from '@services/dot-message/dot-messages.service';
+// import { MockDotMessageService } from '@tests/dot-message-service.mock';
+// import { Site } from '@dotcms/dotcms-js';
+//
+// export const mockDotPageSelectorResults = {
+//     type: 'page',
+//     query: 'about-us',
+//     data: [
+//         {
+//             label: '//demo.dotcms.com/about-us',
+//             payload: {
+//                 template: '8660b482-1ef6-4d00-9459-3996e703ba19',
+//                 owner: 'dotcms.org.1',
+//                 identifier: 'c12fe7e6-d338-49d5-973b-2d974d57015b',
+//                 friendlyname: 'About Us',
+//                 modDate: '2018-05-21 09:52:38.461',
+//                 cachettl: '0',
+//                 pagemetadata: 'dotCMS',
+//                 languageId: 1,
+//                 title: 'About Us',
+//                 showOnMenu: 'true',
+//                 inode: '5cd3b647-e465-4a6d-a78b-e834a7a7331a',
+//                 seodescription: 'dotCMS Content Management System demo site - About Quest',
+//                 folder: '1049e7fe-1553-4731-bdf9-ba069f1dc08b',
+//                 __DOTNAME__: 'About Us',
+//                 sortOrder: 0,
+//                 path: '/about-us',
+//                 seokeywords: 'dotCMS Content Management System',
+//                 modUser: 'dotcms.org.1',
+//                 host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
+//                 lastReview: '2018-05-18 15:30:34.428',
+//                 stInode: 'c541abb1-69b3-4bc5-8430-5e09e5239cc8',
+//                 url: '/about-us/index',
+//                 hostName: 'demo.dotcms.com'
+//             }
+//         }
+//     ]
+// };
+//
+// export const mockDotSiteSelectorResults = {
+//     type: 'site',
+//     query: 'demo.dotcms.com',
+//     data: [
+//         {
+//             label: '//demo.dotcms.com/',
+//             isHost: true,
+//             payload: {
+//                 hostname: 'demo.dotcms.com',
+//                 type: 'host',
+//                 identifier: 's48190c8c-42c4-46af-8d1a-0cd5db894797',
+//                 archived: false
+//             }
+//         }
+//     ]
+// };
+//
+// @Injectable()
+// class MockDotPageSelectorService {
+//     search(_param: string): Observable<DotPageSelectorResults> {
+//         return observableOf(mockDotPageSelectorResults);
+//     }
+//
+//     setCurrentHost(_site: Site) {}
+//
+//     getPageById(_param: string): Observable<DotPageSelectorItem> {
+//         return observableOf(mockDotPageSelectorResults.data[0]);
+//     }
+// }
+// @Component({
+//     selector: 'dot-fake-form',
+//     template: `
+//         <form [formGroup]="form">
+//             <dot-page-selector
+//                 [floatingLabel]="floatingLabel"
+//                 formControlName="page"
+//                 [style]="{ width: '100%' }"
+//                 label="Hello World"
+//             >
+//             </dot-page-selector>
+//         </form>
+//     `
+// })
+// class FakeFormComponent {
+//     form: FormGroup;
+//     floatingLabel = false;
+//
+//     constructor(private fb: FormBuilder) {
+//         /*
+//             This should go in the ngOnInit but I don't want to detectChanges everytime for
+//             this fake test component
+//         */
+//         this.form = this.fb.group({
+//             page: [{ value: 'c12fe7e6-d338-49d5-973b-2d974d57015b', disabled: false }]
+//         });
+//     }
+// }
+//
+// const messageServiceMock = new MockDotMessageService({
+//     'page.selector.no.sites.results': 'Search for sites have no results',
+//     'page.selector.no.page.results': 'Search for pages have no results'
+// });
+//
+// const config = (host) => {
+//     return {
+//         declarations: [host, DotPageSelectorComponent],
+//         imports: [DotDirectivesModule, DotFieldHelperModule],
+//         providers: [
+//             { provide: DotPageSelectorService, useClass: MockDotPageSelectorService },
+//             { provide: LoginService, useClass: LoginServiceMock },
+//             { provide: DotMessageService, useValue: messageServiceMock }
+//         ]
+//     };
+// };
+// let hostDe: DebugElement;
+// let component: DotPageSelectorComponent;
+// let de: DebugElement;
+// let autocomplete: DebugElement;
+// let autocompleteComp: AutoComplete;
+// let dotPageSelectorService: DotPageSelectorService;
+//
+// describe('DotPageSelectorComponent', () => {
+//     let hostFixture: ComponentFixture<FakeFormComponent>;
+//     const searchPageObj = { originalEvent: { target: { value: 'demo' } }, query: 'demo' };
+//     const invalidSearchPageObj = { originalEvent: { target: { value: 'de' } }, query: 'de' };
+//     const searchHostObj = { originalEvent: { target: { value: '//' } }, query: '//' };
+//     const specialSearchObj = { originalEvent: { target: { value: 'd#emo$%' } }, query: 'd#emo$%' };
+//
+//     beforeEach(
+//         waitForAsync(() => {
+//             DOTTestBed.configureTestingModule(config(FakeFormComponent));
+//         })
+//     );
+//
+//     beforeEach(async () => {
+//         hostFixture = DOTTestBed.createComponent(FakeFormComponent);
+//         hostDe = hostFixture.debugElement;
+//         de = hostDe.query(By.css('dot-page-selector'));
+//         component = de.componentInstance;
+//         dotPageSelectorService = de.injector.get(DotPageSelectorService);
+//
+//         spyOn(component.selected, 'emit');
+//         spyOn(component, 'writeValue').and.callThrough();
+//
+//         hostFixture.detectChanges();
+//         await hostFixture.whenStable();
+//         autocomplete = de.query(By.css('p-autoComplete'));
+//         autocompleteComp = autocomplete.componentInstance;
+//     });
+//
+//     it('should have autocomplete', () => {
+//         expect(autocomplete).toBeTruthy();
+//     });
+//
+//     it('shold not set floating label directive', () => {
+//         expect(de.query(By.css('[dotMdInputtext]')) === null).toBe(true);
+//     });
+//
+//     it('should search for pages', () => {
+//         spyOn(dotPageSelectorService, 'search').and.returnValue(
+//             observableOf({ ...mockDotSiteSelectorResults })
+//         );
+//         autocomplete.triggerEventHandler('completeMethod', searchPageObj);
+//         expect(dotPageSelectorService.search).toHaveBeenCalledWith(searchPageObj.query);
+//     });
+//
+//     it('should not search for pages if has less than 3 characters', () => {
+//         component.results = Object.assign({}, mockDotSiteSelectorResults);
+//         spyOn(dotPageSelectorService, 'search').and.returnValue(observableOf(null));
+//         autocomplete.triggerEventHandler('completeMethod', invalidSearchPageObj);
+//
+//         expect(dotPageSelectorService.search).not.toHaveBeenCalled();
+//         expect(component.results.data.length).toBe(0);
+//     });
+//
+//     it('should search for host', () => {
+//         spyOn(dotPageSelectorService, 'search').and.returnValue(
+//             observableOf({ ...mockDotSiteSelectorResults })
+//         );
+//         autocomplete.triggerEventHandler('completeMethod', searchHostObj);
+//         expect(dotPageSelectorService.search).toHaveBeenCalledWith(searchHostObj.query);
+//     });
+//
+//     it('should set current host on selection', () => {
+//         component.results = mockDotSiteSelectorResults;
+//         spyOn<any>(dotPageSelectorService, 'setCurrentHost').and.returnValue(observableOf(null));
+//         autocomplete.triggerEventHandler('onSelect', mockDotSiteSelectorResults.data[0]);
+//         expect(dotPageSelectorService.setCurrentHost).toHaveBeenCalledWith(
+//             mockDotSiteSelectorResults.data[0].payload
+//         );
+//     });
+//
+//     it('should remove special characters when searching for pages', () => {
+//         spyOn(dotPageSelectorService, 'search').and.returnValue(
+//             observableOf({ ...mockDotSiteSelectorResults })
+//         );
+//         autocomplete.triggerEventHandler('completeMethod', specialSearchObj);
+//         expect(dotPageSelectorService.search).toHaveBeenCalledWith('demo');
+//     });
+//
+//     it('should display error when no results in pages', () => {
+//         spyOn(dotPageSelectorService, 'search').and.returnValue(
+//             observableOf({
+//                 type: 'page',
+//                 query: 'invalid',
+//                 data: []
+//             })
+//         );
+//         autocomplete.triggerEventHandler('completeMethod', {
+//             originalEvent: { target: { value: 'invalidPage' } },
+//             query: 'invalidPage'
+//         });
+//
+//         expect(component.message).toEqual('Search for pages have no results');
+//     });
+//
+//     it('should display error when no results in hosts', () => {
+//         spyOn(dotPageSelectorService, 'search').and.returnValue(
+//             observableOf({
+//                 type: 'site',
+//                 query: 'invalid',
+//                 data: []
+//             })
+//         );
+//         autocomplete.triggerEventHandler('completeMethod', {
+//             originalEvent: { target: { value: '//invalid' } },
+//             query: '//invalid'
+//         });
+//
+//         expect(component.message).toEqual('Search for sites have no results');
+//     });
+//
+//     describe('ControlValueAccessor', () => {
+//         beforeEach(() => {
+//             spyOn(component, 'propagateChange').and.callThrough();
+//         });
+//
+//         it('should emit selected item and propagate changes', () => {
+//             component.results = mockDotPageSelectorResults;
+//             autocomplete.triggerEventHandler('onSelect', mockDotPageSelectorResults.data[0]);
+//             expect(component.selected.emit).toHaveBeenCalledWith(
+//                 mockDotPageSelectorResults.data[0].payload
+//             );
+//             expect(component.propagateChange).toHaveBeenCalledWith(
+//                 mockDotPageSelectorResults.data[0].payload.identifier
+//             );
+//         });
+//
+//         it('should write value', () => {
+//             expect(component.writeValue).toHaveBeenCalledWith(
+//                 'c12fe7e6-d338-49d5-973b-2d974d57015b'
+//             );
+//             expect(component.val.payload.identifier).toEqual(
+//                 'c12fe7e6-d338-49d5-973b-2d974d57015b'
+//             );
+//         });
+//
+//         it('should clear model and suggections', () => {
+//             autocomplete.triggerEventHandler('onClear', {});
+//             expect(component.propagateChange).toHaveBeenCalledWith(null);
+//             expect(component.results.data).toEqual([]);
+//         });
+//     });
+//
+//     describe('floating label', () => {
+//         beforeEach(() => {
+//             component.floatingLabel = true;
+//             hostFixture.detectChanges();
+//             autocomplete = de.query(By.css('p-autoComplete'));
+//             autocompleteComp = autocomplete.componentInstance;
+//         });
+//
+//         it('should set floating label directive', () => {
+//             const span: DebugElement = de.query(By.css('.p-field'));
+//             expect(span.componentInstance.label).toBe('Hello World');
+//             expect(span).toBeTruthy();
+//         });
+//
+//         it('should not have placeholder', () => {
+//             expect(autocompleteComp.placeholder).toBeUndefined();
+//         });
+//     });
+// });

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
@@ -11,7 +11,7 @@ import { AutoComplete } from 'primeng/autocomplete';
 import { DotDirectivesModule } from '@shared/dot-directives.module';
 import {
     DotPageSelectorResults,
-    DotPageSeletorItem
+    DotPageSelectorItem
 } from '@components/_common/dot-page-selector/models/dot-page-selector.models';
 import { LoginService } from '@dotcms/dotcms-js';
 import { LoginServiceMock } from '../../../../test/login-service.mock';
@@ -80,7 +80,7 @@ class MockDotPageSelectorService {
 
     setCurrentHost(_site: Site) {}
 
-    getPageById(_param: string): Observable<DotPageSeletorItem> {
+    getPageById(_param: string): Observable<DotPageSelectorItem> {
         return observableOf(mockDotPageSelectorResults.data[0]);
     }
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
@@ -1,300 +1,342 @@
-// import { of as observableOf, Observable } from 'rxjs';
-// import { waitForAsync, ComponentFixture } from '@angular/core/testing';
-// import { By } from '@angular/platform-browser';
-// import { DebugElement, Component, Injectable } from '@angular/core';
-//
-// import { DotPageSelectorComponent } from './dot-page-selector.component';
-// import { DOTTestBed } from '../../../../test/dot-test-bed';
-// import { DotPageSelectorService } from './service/dot-page-selector.service';
-// import { FormGroup, FormBuilder } from '@angular/forms';
-// import { AutoComplete } from 'primeng/autocomplete';
-// import { DotDirectivesModule } from '@shared/dot-directives.module';
-// import {
-//     DotPageSelectorResults,
-//     DotPageSelectorItem
-// } from '@components/_common/dot-page-selector/models/dot-page-selector.models';
-// import { LoginService } from '@dotcms/dotcms-js';
-// import { LoginServiceMock } from '../../../../test/login-service.mock';
-// import { DotFieldHelperModule } from '@components/dot-field-helper/dot-field-helper.module';
-// import { DotMessageService } from '@services/dot-message/dot-messages.service';
-// import { MockDotMessageService } from '@tests/dot-message-service.mock';
-// import { Site } from '@dotcms/dotcms-js';
-//
-// export const mockDotPageSelectorResults = {
-//     type: 'page',
-//     query: 'about-us',
-//     data: [
-//         {
-//             label: '//demo.dotcms.com/about-us',
-//             payload: {
-//                 template: '8660b482-1ef6-4d00-9459-3996e703ba19',
-//                 owner: 'dotcms.org.1',
-//                 identifier: 'c12fe7e6-d338-49d5-973b-2d974d57015b',
-//                 friendlyname: 'About Us',
-//                 modDate: '2018-05-21 09:52:38.461',
-//                 cachettl: '0',
-//                 pagemetadata: 'dotCMS',
-//                 languageId: 1,
-//                 title: 'About Us',
-//                 showOnMenu: 'true',
-//                 inode: '5cd3b647-e465-4a6d-a78b-e834a7a7331a',
-//                 seodescription: 'dotCMS Content Management System demo site - About Quest',
-//                 folder: '1049e7fe-1553-4731-bdf9-ba069f1dc08b',
-//                 __DOTNAME__: 'About Us',
-//                 sortOrder: 0,
-//                 path: '/about-us',
-//                 seokeywords: 'dotCMS Content Management System',
-//                 modUser: 'dotcms.org.1',
-//                 host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
-//                 lastReview: '2018-05-18 15:30:34.428',
-//                 stInode: 'c541abb1-69b3-4bc5-8430-5e09e5239cc8',
-//                 url: '/about-us/index',
-//                 hostName: 'demo.dotcms.com'
-//             }
-//         }
-//     ]
-// };
-//
-// export const mockDotSiteSelectorResults = {
-//     type: 'site',
-//     query: 'demo.dotcms.com',
-//     data: [
-//         {
-//             label: '//demo.dotcms.com/',
-//             isHost: true,
-//             payload: {
-//                 hostname: 'demo.dotcms.com',
-//                 type: 'host',
-//                 identifier: 's48190c8c-42c4-46af-8d1a-0cd5db894797',
-//                 archived: false
-//             }
-//         }
-//     ]
-// };
-//
-// @Injectable()
-// class MockDotPageSelectorService {
-//     search(_param: string): Observable<DotPageSelectorResults> {
-//         return observableOf(mockDotPageSelectorResults);
-//     }
-//
-//     setCurrentHost(_site: Site) {}
-//
-//     getPageById(_param: string): Observable<DotPageSelectorItem> {
-//         return observableOf(mockDotPageSelectorResults.data[0]);
-//     }
-// }
-// @Component({
-//     selector: 'dot-fake-form',
-//     template: `
-//         <form [formGroup]="form">
-//             <dot-page-selector
-//                 [floatingLabel]="floatingLabel"
-//                 formControlName="page"
-//                 [style]="{ width: '100%' }"
-//                 label="Hello World"
-//             >
-//             </dot-page-selector>
-//         </form>
-//     `
-// })
-// class FakeFormComponent {
-//     form: FormGroup;
-//     floatingLabel = false;
-//
-//     constructor(private fb: FormBuilder) {
-//         /*
-//             This should go in the ngOnInit but I don't want to detectChanges everytime for
-//             this fake test component
-//         */
-//         this.form = this.fb.group({
-//             page: [{ value: 'c12fe7e6-d338-49d5-973b-2d974d57015b', disabled: false }]
-//         });
-//     }
-// }
-//
-// const messageServiceMock = new MockDotMessageService({
-//     'page.selector.no.sites.results': 'Search for sites have no results',
-//     'page.selector.no.page.results': 'Search for pages have no results'
-// });
-//
-// const config = (host) => {
-//     return {
-//         declarations: [host, DotPageSelectorComponent],
-//         imports: [DotDirectivesModule, DotFieldHelperModule],
-//         providers: [
-//             { provide: DotPageSelectorService, useClass: MockDotPageSelectorService },
-//             { provide: LoginService, useClass: LoginServiceMock },
-//             { provide: DotMessageService, useValue: messageServiceMock }
-//         ]
-//     };
-// };
-// let hostDe: DebugElement;
-// let component: DotPageSelectorComponent;
-// let de: DebugElement;
-// let autocomplete: DebugElement;
-// let autocompleteComp: AutoComplete;
-// let dotPageSelectorService: DotPageSelectorService;
-//
-// describe('DotPageSelectorComponent', () => {
-//     let hostFixture: ComponentFixture<FakeFormComponent>;
-//     const searchPageObj = { originalEvent: { target: { value: 'demo' } }, query: 'demo' };
-//     const invalidSearchPageObj = { originalEvent: { target: { value: 'de' } }, query: 'de' };
-//     const searchHostObj = { originalEvent: { target: { value: '//' } }, query: '//' };
-//     const specialSearchObj = { originalEvent: { target: { value: 'd#emo$%' } }, query: 'd#emo$%' };
-//
-//     beforeEach(
-//         waitForAsync(() => {
-//             DOTTestBed.configureTestingModule(config(FakeFormComponent));
-//         })
-//     );
-//
-//     beforeEach(async () => {
-//         hostFixture = DOTTestBed.createComponent(FakeFormComponent);
-//         hostDe = hostFixture.debugElement;
-//         de = hostDe.query(By.css('dot-page-selector'));
-//         component = de.componentInstance;
-//         dotPageSelectorService = de.injector.get(DotPageSelectorService);
-//
-//         spyOn(component.selected, 'emit');
-//         spyOn(component, 'writeValue').and.callThrough();
-//
-//         hostFixture.detectChanges();
-//         await hostFixture.whenStable();
-//         autocomplete = de.query(By.css('p-autoComplete'));
-//         autocompleteComp = autocomplete.componentInstance;
-//     });
-//
-//     it('should have autocomplete', () => {
-//         expect(autocomplete).toBeTruthy();
-//     });
-//
-//     it('shold not set floating label directive', () => {
-//         expect(de.query(By.css('[dotMdInputtext]')) === null).toBe(true);
-//     });
-//
-//     it('should search for pages', () => {
-//         spyOn(dotPageSelectorService, 'search').and.returnValue(
-//             observableOf({ ...mockDotSiteSelectorResults })
-//         );
-//         autocomplete.triggerEventHandler('completeMethod', searchPageObj);
-//         expect(dotPageSelectorService.search).toHaveBeenCalledWith(searchPageObj.query);
-//     });
-//
-//     it('should not search for pages if has less than 3 characters', () => {
-//         component.results = Object.assign({}, mockDotSiteSelectorResults);
-//         spyOn(dotPageSelectorService, 'search').and.returnValue(observableOf(null));
-//         autocomplete.triggerEventHandler('completeMethod', invalidSearchPageObj);
-//
-//         expect(dotPageSelectorService.search).not.toHaveBeenCalled();
-//         expect(component.results.data.length).toBe(0);
-//     });
-//
-//     it('should search for host', () => {
-//         spyOn(dotPageSelectorService, 'search').and.returnValue(
-//             observableOf({ ...mockDotSiteSelectorResults })
-//         );
-//         autocomplete.triggerEventHandler('completeMethod', searchHostObj);
-//         expect(dotPageSelectorService.search).toHaveBeenCalledWith(searchHostObj.query);
-//     });
-//
-//     it('should set current host on selection', () => {
-//         component.results = mockDotSiteSelectorResults;
-//         spyOn<any>(dotPageSelectorService, 'setCurrentHost').and.returnValue(observableOf(null));
-//         autocomplete.triggerEventHandler('onSelect', mockDotSiteSelectorResults.data[0]);
-//         expect(dotPageSelectorService.setCurrentHost).toHaveBeenCalledWith(
-//             mockDotSiteSelectorResults.data[0].payload
-//         );
-//     });
-//
-//     it('should remove special characters when searching for pages', () => {
-//         spyOn(dotPageSelectorService, 'search').and.returnValue(
-//             observableOf({ ...mockDotSiteSelectorResults })
-//         );
-//         autocomplete.triggerEventHandler('completeMethod', specialSearchObj);
-//         expect(dotPageSelectorService.search).toHaveBeenCalledWith('demo');
-//     });
-//
-//     it('should display error when no results in pages', () => {
-//         spyOn(dotPageSelectorService, 'search').and.returnValue(
-//             observableOf({
-//                 type: 'page',
-//                 query: 'invalid',
-//                 data: []
-//             })
-//         );
-//         autocomplete.triggerEventHandler('completeMethod', {
-//             originalEvent: { target: { value: 'invalidPage' } },
-//             query: 'invalidPage'
-//         });
-//
-//         expect(component.message).toEqual('Search for pages have no results');
-//     });
-//
-//     it('should display error when no results in hosts', () => {
-//         spyOn(dotPageSelectorService, 'search').and.returnValue(
-//             observableOf({
-//                 type: 'site',
-//                 query: 'invalid',
-//                 data: []
-//             })
-//         );
-//         autocomplete.triggerEventHandler('completeMethod', {
-//             originalEvent: { target: { value: '//invalid' } },
-//             query: '//invalid'
-//         });
-//
-//         expect(component.message).toEqual('Search for sites have no results');
-//     });
-//
-//     describe('ControlValueAccessor', () => {
-//         beforeEach(() => {
-//             spyOn(component, 'propagateChange').and.callThrough();
-//         });
-//
-//         it('should emit selected item and propagate changes', () => {
-//             component.results = mockDotPageSelectorResults;
-//             autocomplete.triggerEventHandler('onSelect', mockDotPageSelectorResults.data[0]);
-//             expect(component.selected.emit).toHaveBeenCalledWith(
-//                 mockDotPageSelectorResults.data[0].payload
-//             );
-//             expect(component.propagateChange).toHaveBeenCalledWith(
-//                 mockDotPageSelectorResults.data[0].payload.identifier
-//             );
-//         });
-//
-//         it('should write value', () => {
-//             expect(component.writeValue).toHaveBeenCalledWith(
-//                 'c12fe7e6-d338-49d5-973b-2d974d57015b'
-//             );
-//             expect(component.val.payload.identifier).toEqual(
-//                 'c12fe7e6-d338-49d5-973b-2d974d57015b'
-//             );
-//         });
-//
-//         it('should clear model and suggections', () => {
-//             autocomplete.triggerEventHandler('onClear', {});
-//             expect(component.propagateChange).toHaveBeenCalledWith(null);
-//             expect(component.results.data).toEqual([]);
-//         });
-//     });
-//
-//     describe('floating label', () => {
-//         beforeEach(() => {
-//             component.floatingLabel = true;
-//             hostFixture.detectChanges();
-//             autocomplete = de.query(By.css('p-autoComplete'));
-//             autocompleteComp = autocomplete.componentInstance;
-//         });
-//
-//         it('should set floating label directive', () => {
-//             const span: DebugElement = de.query(By.css('.p-field'));
-//             expect(span.componentInstance.label).toBe('Hello World');
-//             expect(span).toBeTruthy();
-//         });
-//
-//         it('should not have placeholder', () => {
-//             expect(autocompleteComp.placeholder).toBeUndefined();
-//         });
-//     });
-// });
+import { of as observableOf, Observable } from 'rxjs';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement, Component, Injectable } from '@angular/core';
+
+import { DotPageSelectorComponent } from './dot-page-selector.component';
+import { DotPageAsset, DotPageSelectorService } from './service/dot-page-selector.service';
+import { FormGroup, FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { AutoComplete, AutoCompleteModule } from 'primeng/autocomplete';
+import { DotDirectivesModule } from '@shared/dot-directives.module';
+import {
+    DotFolder,
+    DotPageSelectorItem
+} from '@components/_common/dot-page-selector/models/dot-page-selector.models';
+import { LoginService } from '@dotcms/dotcms-js';
+import { LoginServiceMock } from '../../../../test/login-service.mock';
+import { DotFieldHelperModule } from '@components/dot-field-helper/dot-field-helper.module';
+import { DotMessageService } from '@services/dot-message/dot-messages.service';
+import { MockDotMessageService } from '@tests/dot-message-service.mock';
+import { DotPipesModule } from '@pipes/dot-pipes.module';
+import { CommonModule } from '@angular/common';
+import {
+    expectedFolderMap,
+    expectedPagesMap,
+    expectedSitesMap
+} from '@components/_common/dot-page-selector/service/dot-page-selector.service.spec';
+
+export const mockDotPageSelectorResults = {
+    type: 'page',
+    query: 'about-us',
+    data: [
+        {
+            label: '//demo.dotcms.com/about-us',
+            payload: {
+                template: '8660b482-1ef6-4d00-9459-3996e703ba19',
+                owner: 'dotcms.org.1',
+                identifier: 'c12fe7e6-d338-49d5-973b-2d974d57015b',
+                friendlyname: 'About Us',
+                modDate: '2018-05-21 09:52:38.461',
+                cachettl: '0',
+                pagemetadata: 'dotCMS',
+                languageId: 1,
+                title: 'About Us',
+                showOnMenu: 'true',
+                inode: '5cd3b647-e465-4a6d-a78b-e834a7a7331a',
+                seodescription: 'dotCMS Content Management System demo site - About Quest',
+                folder: '1049e7fe-1553-4731-bdf9-ba069f1dc08b',
+                __DOTNAME__: 'About Us',
+                sortOrder: 0,
+                path: '/about-us',
+                seokeywords: 'dotCMS Content Management System',
+                modUser: 'dotcms.org.1',
+                host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
+                lastReview: '2018-05-18 15:30:34.428',
+                stInode: 'c541abb1-69b3-4bc5-8430-5e09e5239cc8',
+                url: '/about-us/index',
+                hostName: 'demo.dotcms.com'
+            }
+        }
+    ]
+};
+
+@Injectable()
+class MockDotPageSelectorService {
+    getPageById(_param: string): Observable<DotPageSelectorItem> {
+        return observableOf(mockDotPageSelectorResults.data[0]);
+    }
+
+    getPages(_param: string): Observable<DotPageSelectorItem[]> {
+        return observableOf(expectedPagesMap);
+    }
+
+    getFolders(_param: string): Observable<DotPageSelectorItem[]> {
+        return observableOf(expectedFolderMap);
+    }
+
+    getSites(_param: string): Observable<DotPageSelectorItem[]> {
+        return observableOf(expectedSitesMap);
+    }
+}
+@Component({
+    selector: 'dot-fake-form',
+    template: `
+        <form [formGroup]="form">
+            <dot-page-selector
+                formControlName="page"
+                [style]="{ width: '100%' }"
+                label="Hello World"
+            >
+            </dot-page-selector>
+        </form>
+    `
+})
+class FakeFormComponent {
+    form: FormGroup;
+
+    constructor(private fb: FormBuilder) {
+        /*
+            This should go in the ngOnInit but I don't want to detectChanges everytime for
+            this fake test component
+        */
+        this.form = this.fb.group({
+            page: [{ value: 'c12fe7e6-d338-49d5-973b-2d974d57015b', disabled: false }]
+        });
+    }
+}
+
+const messageServiceMock = new MockDotMessageService({
+    'page.selector.no.sites.results': 'Search for sites have no results',
+    'page.selector.no.page.results': 'Search for pages have no results',
+    'page.selector.no.folder.results': 'Search for folders have no results',
+    'page.selector.placeholder': 'Start typing for suggestions',
+    'page.selector.folder.hint': 'Folder hint',
+    'page.selector.hint': 'Page hint',
+    'page.selector.folder.permissions': 'Folder Permissions',
+    'page.selector.folder.new': 'new folder'
+});
+
+let hostDe: DebugElement;
+let component: DotPageSelectorComponent;
+let de: DebugElement;
+let autocomplete: DebugElement;
+let autocompleteComp: AutoComplete;
+let dotPageSelectorService: DotPageSelectorService;
+
+describe('DotPageSelectorComponent', () => {
+    let hostFixture: ComponentFixture<FakeFormComponent>;
+    const searchPageObj = { originalEvent: { target: { value: 'demo' } }, query: 'demo' };
+    const searchFolderObj = { originalEvent: { target: { value: 'folder' } }, query: 'folder' };
+    const invalidSearchPageObj = { originalEvent: { target: { value: 'd' } }, query: 'd' };
+    const searchHostObj = { originalEvent: { target: { value: '//' } }, query: '//' };
+    const specialSearchObj = { originalEvent: { target: { value: 'd#emo$%' } }, query: 'd#emo$%' };
+    const fullSearchObj = {
+        originalEvent: { target: { value: '//demo/folder' } },
+        query: '//demo/folder'
+    };
+    const completeHostSearch = {
+        originalEvent: { target: { value: '//demo/' } },
+        query: '//demo/'
+    };
+
+    beforeEach(
+        waitForAsync(() => {
+            TestBed.configureTestingModule({
+                declarations: [FakeFormComponent, DotPageSelectorComponent],
+                imports: [
+                    DotDirectivesModule,
+                    DotFieldHelperModule,
+                    DotPipesModule,
+                    AutoCompleteModule,
+                    FormsModule,
+                    CommonModule,
+                    ReactiveFormsModule
+                ],
+                providers: [
+                    { provide: DotPageSelectorService, useClass: MockDotPageSelectorService },
+                    { provide: LoginService, useClass: LoginServiceMock },
+                    { provide: DotMessageService, useValue: messageServiceMock }
+                ]
+            }).compileComponents();
+        })
+    );
+
+    beforeEach(async () => {
+        hostFixture = TestBed.createComponent(FakeFormComponent);
+        hostDe = hostFixture.debugElement;
+        de = hostDe.query(By.css('dot-page-selector'));
+        component = de.componentInstance;
+        dotPageSelectorService = de.injector.get(DotPageSelectorService);
+
+        spyOn(component.selected, 'emit');
+        spyOn(component, 'writeValue').and.callThrough();
+
+        hostFixture.detectChanges();
+        await hostFixture.whenStable();
+        autocomplete = de.query(By.css('[data-testId="p-autoComplete"]'));
+        autocompleteComp = autocomplete.componentInstance;
+    });
+
+    describe('AutoComplete properties', () => {
+        it('should have placeholder', () => {
+            const input: HTMLInputElement = de.query(By.css('.p-autocomplete-input')).nativeElement;
+            expect(input.placeholder).toEqual('Start typing for suggestions');
+        });
+    });
+
+    describe('Search Types', () => {
+        it('should search for pages', () => {
+            spyOn(dotPageSelectorService, 'getPages').and.callThrough();
+            autocomplete.triggerEventHandler('completeMethod', searchPageObj);
+            expect(dotPageSelectorService.getPages).toHaveBeenCalledWith(searchPageObj.query);
+        });
+
+        it('should not search for pages if has less than 2 characters', () => {
+            spyOn(dotPageSelectorService, 'getPages').and.callThrough();
+            autocomplete.triggerEventHandler('completeMethod', invalidSearchPageObj);
+            expect(dotPageSelectorService.getPages).not.toHaveBeenCalled();
+        });
+
+        it('should search for host', () => {
+            spyOn(dotPageSelectorService, 'getSites').and.callThrough();
+            autocomplete.triggerEventHandler('completeMethod', searchHostObj);
+            expect(dotPageSelectorService.getSites).toHaveBeenCalledWith('');
+        });
+
+        it('should search for pages when the host is complete', () => {
+            spyOn(dotPageSelectorService, 'getSites').and.callThrough();
+            spyOn(dotPageSelectorService, 'getPages').and.callThrough();
+            autocomplete.triggerEventHandler('completeMethod', completeHostSearch);
+            expect(dotPageSelectorService.getSites).toHaveBeenCalledWith('demo', true);
+            expect(dotPageSelectorService.getPages).toHaveBeenCalledWith('//demo/');
+        });
+
+        it('should remove special characters when searching for pages', () => {
+            spyOn(dotPageSelectorService, 'getPages').and.callThrough();
+            autocomplete.triggerEventHandler('completeMethod', specialSearchObj);
+            expect(dotPageSelectorService.getPages).toHaveBeenCalledWith('demo');
+        });
+
+        it('should display error when no results in pages', () => {
+            spyOn(dotPageSelectorService, 'getPages').and.returnValue(observableOf([]));
+            autocomplete.triggerEventHandler('completeMethod', {
+                originalEvent: { target: { value: 'invalidPage' } },
+                query: 'invalidPage'
+            });
+            hostFixture.detectChanges();
+            const message = de.query(By.css('[data-testId="message"]'));
+            expect(message.nativeNode.textContent).toEqual('Search for pages have no results');
+            expect(message.nativeNode).toHaveClass('p-invalid');
+        });
+
+        it('should display error when no results in hosts', () => {
+            spyOn(dotPageSelectorService, 'getSites').and.returnValue(observableOf([]));
+            autocomplete.triggerEventHandler('completeMethod', {
+                originalEvent: { target: { value: '//invalid' } },
+                query: '//invalid'
+            });
+            hostFixture.detectChanges();
+            const message = de.query(By.css('[data-testId="message"]'));
+            expect(message.nativeNode.textContent).toEqual('Search for sites have no results');
+            expect(message.nativeNode).toHaveClass('p-invalid');
+        });
+
+        describe('folder search ', () => {
+            beforeEach(() => {
+                component.folderSearch = true;
+                hostFixture.detectChanges();
+            });
+
+            it('should search for folders', () => {
+                spyOn(dotPageSelectorService, 'getFolders').and.callThrough();
+                autocomplete.triggerEventHandler('completeMethod', searchFolderObj);
+                expect(dotPageSelectorService.getFolders).toHaveBeenCalledWith(
+                    searchFolderObj.query
+                );
+            });
+
+            it('should show message new folder will be created', () => {
+                spyOn(dotPageSelectorService, 'getSites').and.callThrough();
+                spyOn(dotPageSelectorService, 'getFolders').and.returnValue(observableOf([]));
+                autocomplete.triggerEventHandler('completeMethod', fullSearchObj);
+                hostFixture.detectChanges();
+                const message = de.query(By.css('[data-testId="message"]'));
+                expect(message.nativeNode.textContent).toEqual('new folder');
+                expect(message.nativeNode).toHaveClass('p-info');
+            });
+
+            it('should show message of permissions', () => {
+                spyOn(dotPageSelectorService, 'getFolders').and.callThrough();
+                autocomplete.triggerEventHandler('completeMethod', searchFolderObj);
+                autocomplete.triggerEventHandler('onSelect', expectedFolderMap[1]);
+                hostFixture.detectChanges();
+                const message = de.query(By.css('[data-testId="message"]'));
+                expect(message.nativeNode.textContent).toEqual('Folder Permissions');
+                expect(message.nativeNode).toHaveClass('p-invalid');
+            });
+
+            it('should display error when no results in folders', () => {
+                spyOn(dotPageSelectorService, 'getFolders').and.returnValue(observableOf([]));
+                autocomplete.triggerEventHandler('completeMethod', {
+                    originalEvent: { target: { value: 'invalid' } },
+                    query: 'invalid'
+                });
+                hostFixture.detectChanges();
+                const message = de.query(By.css('[data-testId="message"]'));
+                expect(message.nativeNode.textContent).toEqual(
+                    'Search for folders have no results'
+                );
+                expect(message.nativeNode).toHaveClass('p-invalid');
+            });
+        });
+    });
+
+    describe('ControlValueAccessor', () => {
+        beforeEach(() => {
+            spyOn(component, 'propagateChange').and.callThrough();
+        });
+
+        it('should emit selected page and propagate changes', () => {
+            spyOn(dotPageSelectorService, 'getPages').and.callThrough();
+            autocomplete.triggerEventHandler('completeMethod', searchPageObj);
+            autocomplete.triggerEventHandler('onSelect', expectedPagesMap[0]);
+            expect(component.selected.emit).toHaveBeenCalledWith(
+                expectedPagesMap[0].payload as DotPageAsset
+            );
+            expect(component.propagateChange).toHaveBeenCalledWith(
+                (expectedPagesMap[0].payload as DotPageAsset).identifier
+            );
+        });
+
+        it('should write value', () => {
+            expect(component.writeValue).toHaveBeenCalledWith(
+                'c12fe7e6-d338-49d5-973b-2d974d57015b'
+            );
+            expect((component.val.payload as DotPageAsset).identifier).toEqual(
+                'c12fe7e6-d338-49d5-973b-2d974d57015b'
+            );
+        });
+
+        it('should clear model and suggestions', () => {
+            component.suggestions$.subscribe((value) => {
+                expect(value).toEqual([]);
+            });
+            autocomplete.triggerEventHandler('onClear', {});
+            expect(component.propagateChange).toHaveBeenCalledWith(null);
+        });
+
+        it('should emit selected folder and propagate changes', () => {
+            component.folderSearch = true;
+            const folder = <DotFolder>expectedFolderMap[0].payload;
+            spyOn(dotPageSelectorService, 'getFolders').and.callThrough();
+            autocomplete.triggerEventHandler('completeMethod', searchFolderObj);
+            autocomplete.triggerEventHandler('onSelect', expectedFolderMap[0]);
+            expect(component.selected.emit).toHaveBeenCalledWith(
+                `//${folder.hostName}${folder.path}`
+            );
+            expect(component.propagateChange).toHaveBeenCalledWith(
+                `//${folder.hostName}${folder.path}`
+            );
+        });
+    });
+});

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
@@ -53,18 +53,13 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
     val: DotPageSelectorItem;
     suggestions: Subject<any> = new Subject<any>();
     emptyMessage: string;
+    searchType: string;
     private currentHost: Site;
-    private searchType: string;
 
     constructor(
         private dotPageSelectorService: DotPageSelectorService,
         private dotMessageService: DotMessageService
-    ) {
-        this.suggestions.subscribe((data) => {
-            console.log('suggestions: ', data);
-            this.autoComplete.show();
-        });
-    }
+    ) {}
 
     propagateChange = (_: any) => {};
 
@@ -86,12 +81,12 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
      */
     search(param: any): void {
         const query = this.cleanAndValidateQuery(param.query);
-        console.log('search', query);
         if (!!query) {
             this.handleSearchType(query)
                 .pipe(take(1))
                 .subscribe((data) => {
                     this.suggestions.next(data);
+                    this.autoComplete.show();
                     this.emptyMessage = !!data.length ? null : this.getEmptyMessage();
                 });
         } else {
@@ -106,7 +101,6 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
      * @memberof DotPageSelectorComponent
      */
     onSelect(item: DotPageSelectorItem): void {
-        console.log('onSelect');
         if (this.searchType === 'site') {
             const site: Site = <Site>item.payload;
             this.currentHost = site;
@@ -164,7 +158,6 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
     registerOnTouched(_fn: any): void {}
 
     private handleSearchType(query: string): Observable<DotPageSelectorItem[]> {
-        console.log('isTwoStepSearch: ', this.isTwoStepSearch(query));
         if (this.isTwoStepSearch(query)) {
             return this.fullSearch(query);
         } else {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
@@ -22,7 +22,7 @@ import {
 } from './models/dot-page-selector.models';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
 import { AutoComplete } from 'primeng/autocomplete';
-import { of } from 'rxjs/internal/observable/of';
+import { of } from 'rxjs';
 import { Observable, Subject } from 'rxjs';
 
 const NO_SPECIAL_CHAR = /^[a-zA-Z0-9._/-]*$/g;

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
@@ -93,13 +93,6 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
                 .subscribe((data) => {
                     this.suggestions.next(data);
                     this.emptyMessage = !!data.length ? null : this.getEmptyMessage();
-                    // if (data.length === 1 && this.isSearchingForHost(query)) {
-                    //     console.log('autoSelectUniqueResult');
-                    //     this.autoSelectUniqueResult(data[0]);
-                    // }
-                    // if ( this.shouldAutoFill() && this.isOnlyFullHost(query)) {
-                    //     this.autoSelectUniqueResult();
-                    // }
                 });
         } else {
             this.resetResults();
@@ -139,11 +132,6 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
      */
     onKeyEnter($event: KeyboardEvent): void {
         $event.stopPropagation();
-
-        // if (this.shouldAutoFill()) {
-        //     this.autoFillField($event);
-        //     // this.autoSelectUniqueResult();
-        // }
     }
 
     /**
@@ -199,18 +187,6 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
                 }
             })
         );
-
-        // return this.getSites(host, true).pipe(
-        //     take(1),
-        //     switchMap((results: DotPageSelectorResults) => {
-        //         if (results.data.length) {
-        //             this.setCurrentHost(<Site>results.data[0].payload);
-        //             return this.isFolderSearch ? this.getFolders(param) : this.getPages(param);
-        //         } else {
-        //             return of(results);
-        //         }
-        //     })
-        // );
     }
 
     private conditionalSearch(param: string): Observable<DotPageSelectorItem[]> {
@@ -221,24 +197,6 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
                   })
               )
             : this.getSecondStepData(param);
-
-        // return !this.currentHost || this.isReSearchingForHost(param)
-        //     ? this.dotPageSelectorService.getSites(this.getSiteName(param)).pipe(
-        //           tap(() => {
-        //               this.searchType = 'site';
-        //           })
-        //       )
-        //     : this.folderSearch
-        //     ? this.dotPageSelectorService.getFolders(param).pipe(
-        //           tap(() => {
-        //               this.searchType = 'folder';
-        //           })
-        //       )
-        //     : this.dotPageSelectorService.getPages(param).pipe(
-        //           tap(() => {
-        //               this.searchType = 'page';
-        //           })
-        //       );
     }
 
     private getSecondStepData(param: string): Observable<DotPageSelectorItem[]> {
@@ -256,13 +214,11 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
     }
 
     private isTwoStepSearch(param: string): boolean {
-        // return !!this.currentHost || this.hostChanged(param);
         return (
             param.startsWith('//') &&
             param.length > 2 &&
             (this.isHostAndPath(param) || param.endsWith('/'))
         );
-        // return this.isHostAndPath(param) && (!this.currentHost || this.hostChanged(param));
     }
 
     private isHostAndPath(param: string): boolean {
@@ -277,128 +233,29 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
         } catch {
             return null;
         }
-
-        // if (this.isSearchingForHost(query)) {
-        //     try {
-        //         const url = new URL(`http:${query}`);
-        //         return {
-        //             host: url.host,
-        //             pathname:
-        //                 query.endsWith('/') && url.pathname.length === 1
-        //                     ? ' '
-        //                     : url.pathname.substr(1)
-        //         };
-        //     } catch {
-        //         return null;
-        //     }
-        // } else {
-        //     return null;
-        // }
     }
 
     private isSearchingForHost(query: string): boolean {
         return query.startsWith('//') && !!this.getSiteName(query) ? !query.endsWith('/') : true;
     }
 
-    // private shouldSearchPages(query: string): boolean {
-    //     debugger;
-    //     if (!this.isHostAndPath(query) || this.isReSearchingForHost(query)) {
-    //         this.currentHost = null;
-    //     }
-    //     console.log(!!(this.currentHost || !this.isSearchingForHost(query)));
-    //     return !!(this.currentHost || !this.isSearchingForHost(query));
-    // }
-
-    // private isReSearchingForHost(query: string): boolean {
-    //     console.log('hostChanged', this.hostChanged(query));
-    //     if (this.isSearchingForHost(query) && this.hostChanged(query)) {
-    //         this.currentHost = null;
-    //         return true;
-    //     }
-    //     return false;
-    // }
-
-    // private hostChanged(query: string): boolean {
-    //     const parsedURL = this.parseUrl(query);
-    //     return (
-    //         this.currentHost &&
-    //         parsedURL &&
-    //         this.currentHost.hostname.toLocaleLowerCase() !== parsedURL.host.toLocaleLowerCase()
-    //     );
-    // }
-
     private getSiteName(site: string): string {
         return site.replace(/\//g, '');
     }
-
-    // private autoFillField($event: KeyboardEvent): void {
-    //     const input: HTMLInputElement = <HTMLInputElement>$event.target;
-    //
-    //     if (this.searchType === 'site') {
-    //         const host = <Site>this.autoComplete.suggestions[0].payload;
-    //         input.value = `//${host.hostname}/`;
-    //     } else if (this.searchType === 'page') {
-    //         const page = <DotPageAsset>this.autoComplete.suggestions[0].payload;
-    //         input.value = `//${page.hostName}/${page.path}`;
-    //     } else if (this.searchType === 'folder') {
-    //         const folder = <DotFolder>this.autoComplete.suggestions[0].payload;
-    //         input.value = `//${folder.hostname}${folder.path}`;
-    //     }
-    //
-    //     this.resetResults();
-    // }
-
-    // private shouldAutoFill(): boolean {
-    //     debugger;
-    //     return this.autoComplete.suggestions.length === 1;
-    // }
 
     private resetResults(): void {
         this.suggestions.next(of([]));
     }
 
-    // private getErrorMessage(): string {
-    //     return this.results.data.length === 0 ? this.getEmptyMessage(this.results.type) : null;
-    // }
-
-    // private isOnlyFullHost(host: string): boolean {
-    //     return /\/\/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\/*$/.test(host);
-    // }
-
-    // private autoSelectUniqueResult(data: DotPageSelectorItem): void {
-    //     this.onSelect(data);
-    // }
-
     private cleanAndValidateQuery(query: string): string {
         const cleanedQuery = this.cleanQuery(query);
         this.autoComplete.inputEL.nativeElement.value = cleanedQuery;
-        debugger;
         return cleanedQuery.startsWith('//')
             ? cleanedQuery
             : cleanedQuery.length >= 3
             ? cleanedQuery
             : '';
-
-        // return !!cleanedQuery
-        //     ? cleanedQuery.startsWith('//')
-        //         ? cleanedQuery
-        //         : cleanedQuery.length >= 3
-        //         ? cleanedQuery
-        //         : ''
-        //     : '';
     }
-
-    // private validSearch(param: any): boolean {
-    //     return (
-    //         this.cleanInput(param).length &&
-    //         (param.query.startsWith('//') ? true : param.query.length >= 3)
-    //     );
-    // }
-
-    // private cleanInput(event: any): string {
-    //     this.autoComplete.inputEL.nativeElement.value = this.cleanQuery(event.query);
-    //     return this.autoComplete.inputEL.nativeElement.value;
-    // }
 
     private cleanQuery(query: string): string {
         return !NO_SPECIAL_CHAR.test(query) ? query.replace(REPLACE_SPECIAL_CHAR, '') : query;

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
@@ -55,7 +55,6 @@ enum SearchType {
 export class DotPageSelectorComponent implements ControlValueAccessor {
     @Output() selected = new EventEmitter<DotPageAsset | string>();
     @Input() label: string;
-    @Input() floatingLabel = false;
     @Input() folderSearch = false;
 
     @ViewChild('autoComplete') autoComplete: AutoComplete;
@@ -126,8 +125,8 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
         } else if (this.searchType === 'folder') {
             const folder = <DotFolder>item.payload;
             if (folder.addChildrenAllowed) {
-                this.selected.emit(`//${folder.hostname}${folder.path}`);
-                this.propagateChange(`//${folder.hostname}${folder.path}`);
+                this.selected.emit(`//${folder.hostName}${folder.path}`);
+                this.propagateChange(`//${folder.hostName}${folder.path}`);
             } else {
                 this.message = this.dotMessageService.get('page.selector.folder.permissions');
                 this.isError = true;

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
@@ -1,13 +1,29 @@
-import { Component, Output, EventEmitter, forwardRef, Input } from '@angular/core';
+import {
+    Component,
+    Output,
+    EventEmitter,
+    forwardRef,
+    Input,
+    OnInit,
+    ViewChild
+} from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { take } from 'rxjs/operators';
+import { map, switchMap, take, tap } from 'rxjs/operators';
 
 import { Site } from '@dotcms/dotcms-js';
 
 import { DotPageSelectorService, DotPageAsset } from './service/dot-page-selector.service';
-import { DotPageSelectorResults, DotPageSeletorItem } from './models/dot-page-selector.models';
+import {
+    DotPageSelectorResults,
+    DotPageSelectorItem,
+    DotFolder,
+    DotSimpleURL
+} from './models/dot-page-selector.models';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
+import { AutoComplete } from 'primeng/autocomplete';
+import { of } from 'rxjs/internal/observable/of';
+import { Observable, Subject } from 'rxjs';
 
 const NO_SPECIAL_CHAR = /^[a-zA-Z0-9._/-]*$/g;
 const REPLACE_SPECIAL_CHAR = /[^a-zA-Z0-9._/-]/g;
@@ -32,17 +48,23 @@ const REPLACE_SPECIAL_CHAR = /[^a-zA-Z0-9._/-]/g;
     ]
 })
 export class DotPageSelectorComponent implements ControlValueAccessor {
-    @Output() selected = new EventEmitter<DotPageAsset>();
+    @Output() selected = new EventEmitter<DotPageAsset | string>();
     @Input() label: string;
     @Input() floatingLabel = false;
+    @Input() folderSearch = false;
 
-    results: DotPageSelectorResults = {
-        data: [],
-        query: '',
-        type: ''
-    };
-    val: DotPageSeletorItem;
+    @ViewChild('autoComplete') autoComplete: AutoComplete;
+
+    // results: DotPageSelectorResults = {
+    //     data: of([]),
+    //     query: '',
+    //     type: ''
+    // };
+    val: DotPageSelectorItem;
     message: string;
+    suggestions: Subject<any> = new Subject<any>();
+    private currentHost: Site;
+    private searchType: string;
 
     constructor(
         private dotPageSelectorService: DotPageSelectorService,
@@ -58,7 +80,34 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
      */
     onClear(): void {
         this.propagateChange(null);
-        this.results.data = [];
+        this.suggestions.next(of([]));
+    }
+
+    /**
+     * Get results and set it to the autotomplete
+     *
+     * @param string param
+     * @memberof DotPageSelectorComponent
+     */
+    search(param: any): void {
+        console.log('search');
+        if (this.validSearch(param)) {
+            debugger;
+            this.handleSearchType(this.cleanQuery(param.query))
+                .pipe(take(1))
+                .subscribe((data) => {
+                    debugger;
+                    this.suggestions.next(data);
+                    if (
+                        this.shouldAutoFill() &&
+                        this.isOnlyFullHost(this.cleanQuery(param.query))
+                    ) {
+                        this.autoSelectUniqueResult();
+                    }
+                });
+        } else {
+            this.resetResults();
+        }
     }
 
     /**
@@ -67,14 +116,20 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
      * @param DotPageAsset item
      * @memberof DotPageSelectorComponent
      */
-    onSelect(item: DotPageSeletorItem): void {
-        if (this.results.type === 'site') {
+    onSelect(item: DotPageSelectorItem): void {
+        console.log('onSelect');
+        if (this.searchType === 'site') {
             const site: Site = <Site>item.payload;
-            this.dotPageSelectorService.setCurrentHost(site);
-        } else if (this.results.type === 'page') {
+            this.currentHost = site;
+            this.autoComplete.completeMethod.emit({ query: `//${site.hostname}/` });
+        } else if (this.searchType === 'page') {
             const page: DotPageAsset = <DotPageAsset>item.payload;
             this.selected.emit(page);
             this.propagateChange(page.identifier);
+        } else if (this.searchType === 'folder') {
+            const folder = <DotFolder>item.payload;
+            this.selected.emit(`${folder.hostname}${folder.path}`);
+            this.propagateChange(`${folder.hostname}${folder.path}`);
         }
 
         this.resetResults();
@@ -96,33 +151,6 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
     }
 
     /**
-     * Get pages results and set it to the autotomplete
-     *
-     * @param string param
-     * @memberof DotPageSelectorComponent
-     */
-    search(param: any): void {
-        if (this.validSearch(param)) {
-            this.dotPageSelectorService
-                .search(this.cleanQuery(param.query))
-                .pipe(take(1))
-                .subscribe((results: DotPageSelectorResults) => {
-                    this.results = results;
-                    this.message = this.getErrorMessage();
-
-                    if (
-                        this.shouldAutoFill() &&
-                        this.isOnlyFullHost(this.cleanQuery(param.query))
-                    ) {
-                        this.autoSelectUniqueResult();
-                    }
-                });
-        } else {
-            this.results.data = [];
-        }
-    }
-
-    /**
      * Write a new value to the element
      *
      * @param string idenfier
@@ -133,7 +161,7 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
             this.dotPageSelectorService
                 .getPageById(idenfier)
                 .pipe(take(1))
-                .subscribe((item: DotPageSeletorItem) => {
+                .subscribe((item: DotPageSelectorItem) => {
                     this.val = item;
                 });
         }
@@ -151,46 +179,173 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
 
     registerOnTouched(_fn: any): void {}
 
+    private handleSearchType(query: string): Observable<DotPageSelectorItem[]> {
+        if (this.isTwoStepSearch(query)) {
+            return this.fullSearch(query);
+        } else {
+            return this.conditionalSearch(query);
+        }
+    }
+
+    private fullSearch(param: string): Observable<DotPageSelectorItem[]> {
+        const host = this.parseUrl(param).host;
+        return this.dotPageSelectorService.getSites(host, true).pipe(
+            take(1),
+            switchMap((results: DotPageSelectorItem[]) => {
+                if (results.length) {
+                    this.currentHost = <Site>results[0].payload;
+                    return this.folderSearch
+                        ? this.dotPageSelectorService.getFolders(param).pipe(
+                              tap(() => {
+                                  this.searchType = 'folder';
+                              })
+                          )
+                        : this.dotPageSelectorService.getPages(param).pipe(
+                              tap(() => {
+                                  this.searchType = 'page';
+                              })
+                          );
+                } else {
+                    return of(results);
+                }
+            })
+        );
+
+        // return this.getSites(host, true).pipe(
+        //     take(1),
+        //     switchMap((results: DotPageSelectorResults) => {
+        //         if (results.data.length) {
+        //             this.setCurrentHost(<Site>results.data[0].payload);
+        //             return this.isFolderSearch ? this.getFolders(param) : this.getPages(param);
+        //         } else {
+        //             return of(results);
+        //         }
+        //     })
+        // );
+    }
+
+    private conditionalSearch(param: string): Observable<DotPageSelectorItem[]> {
+        debugger;
+        return !this.currentHost || this.isReSearchingForHost(param)
+            ? this.dotPageSelectorService.getSites(this.getSiteName(param)).pipe(
+                  tap(() => {
+                      this.searchType = 'site';
+                  })
+              )
+            : this.folderSearch
+            ? this.dotPageSelectorService.getFolders(param).pipe(
+                  tap(() => {
+                      this.searchType = 'folder';
+                  })
+              )
+            : this.dotPageSelectorService.getPages(param).pipe(
+                  tap(() => {
+                      this.searchType = 'page';
+                  })
+              );
+    }
+
+    private isTwoStepSearch(param): boolean {
+        // return !!this.currentHost || this.hostChanged(param);
+        return this.isHostAndPath(param) && (!this.currentHost || this.hostChanged(param));
+    }
+
+    private isHostAndPath(param: string): boolean {
+        const url: DotSimpleURL | { [key: string]: string } = this.parseUrl(param);
+        return url && !!(url.host && url.pathname.length > 0);
+    }
+
+    private parseUrl(query: string): DotSimpleURL {
+        if (this.isSearchingForHost(query)) {
+            try {
+                const url = new URL(`http:${query}`);
+                debugger;
+                return {
+                    host: url.host,
+                    pathname:
+                        query.endsWith('/') && url.pathname.length === 1
+                            ? ' '
+                            : url.pathname.substr(1)
+                };
+            } catch {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private isSearchingForHost(query: string): boolean {
+        return query.startsWith('//') && !!this.getSiteName(query) ? !query.endsWith('/') : true;
+    }
+
+    private shouldSearchPages(query: string): boolean {
+        debugger;
+        if (!this.isHostAndPath(query) || this.isReSearchingForHost(query)) {
+            this.currentHost = null;
+        }
+        console.log(!!(this.currentHost || !this.isSearchingForHost(query)));
+        return !!(this.currentHost || !this.isSearchingForHost(query));
+    }
+
+    private isReSearchingForHost(query: string): boolean {
+        console.log('hostChanged', this.hostChanged(query));
+        if (this.isSearchingForHost(query) && this.hostChanged(query)) {
+            this.currentHost = null;
+            return true;
+        }
+        return false;
+    }
+
+    private hostChanged(query: string): boolean {
+        const parsedURL = this.parseUrl(query);
+        return (
+            this.currentHost &&
+            parsedURL &&
+            this.currentHost.hostname.toLocaleLowerCase() !== parsedURL.host.toLocaleLowerCase()
+        );
+    }
+
+    private getSiteName(site: string): string {
+        return site.replace(/\//g, '');
+    }
+
     private autoFillField($event: KeyboardEvent): void {
         const input: HTMLInputElement = <HTMLInputElement>$event.target;
 
-        if (this.results.type === 'site') {
-            const host = <Site>this.results.data[0].payload;
+        if (this.searchType === 'site') {
+            const host = <Site>this.autoComplete.suggestions[0].payload;
             input.value = `//${host.hostname}/`;
-        } else if (this.results.type === 'page') {
-            const page = <DotPageAsset>this.results.data[0].payload;
-            input.value = `//demo.dotcms.com${page.path}`;
+        } else if (this.searchType === 'page') {
+            const page = <DotPageAsset>this.autoComplete.suggestions[0].payload;
+            input.value = `//${page.hostName}/${page.path}`;
+        } else if (this.searchType === 'folder') {
+            const folder = <DotFolder>this.autoComplete.suggestions[0].payload;
+            input.value = `//${folder.hostname}${folder.path}`;
         }
 
         this.resetResults();
     }
 
     private shouldAutoFill(): boolean {
-        return this.results.data.length === 1;
+        debugger;
+        return this.autoComplete.suggestions.length === 1;
     }
 
     private resetResults(): void {
-        this.results = {
-            data: [],
-            query: '',
-            type: ''
-        };
+        this.suggestions.next(of([]));
     }
 
-    private getErrorMessage(): string {
-        return this.results.data.length === 0
-            ? this.results.type === 'site'
-                ? this.dotMessageService.get('page.selector.no.sites.results')
-                : this.dotMessageService.get('page.selector.no.page.results')
-            : null;
-    }
+    // private getErrorMessage(): string {
+    //     return this.results.data.length === 0 ? this.getEmptyMessage(this.results.type) : null;
+    // }
 
     private isOnlyFullHost(host: string): boolean {
         return /\/\/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\/*$/.test(host);
     }
 
     private autoSelectUniqueResult(): void {
-        this.onSelect(this.results.data[0]);
+        this.onSelect(this.autoComplete.suggestions[0]);
     }
 
     private validSearch(param: any): boolean {
@@ -201,11 +356,22 @@ export class DotPageSelectorComponent implements ControlValueAccessor {
     }
 
     private cleanInput(event: any): string {
-        event.originalEvent.target.value = this.cleanQuery(event.query);
-        return event.originalEvent.target.value;
+        this.autoComplete.inputEL.nativeElement.value = this.cleanQuery(event.query);
+        return this.autoComplete.inputEL.nativeElement.value;
     }
 
     private cleanQuery(query: string): string {
         return !NO_SPECIAL_CHAR.test(query) ? query.replace(REPLACE_SPECIAL_CHAR, '') : query;
+    }
+
+    private getEmptyMessage(type: string): string {
+        switch (type) {
+            case 'site':
+                return this.dotMessageService.get('page.selector.no.sites.results');
+            case 'page':
+                return this.dotMessageService.get('page.selector.no.page.results');
+            case 'folder':
+                return this.dotMessageService.get('page.selector.no.folder.results');
+        }
     }
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
@@ -16,3 +16,8 @@ export interface DotFolder {
     path: string;
     addChildrenAllowed: boolean;
 }
+
+export interface CompleteEvent {
+    originalEvent: InputEvent;
+    query: string;
+}

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
@@ -1,16 +1,9 @@
 import { DotPageAsset } from '../service/dot-page-selector.service';
 import { Site } from '@dotcms/dotcms-js';
-import { Observable } from 'rxjs';
 
 export interface DotPageSelectorItem {
     label: string;
     payload: DotPageAsset | Site | DotFolder;
-}
-
-export interface DotPageSelectorResults {
-    data: Observable<DotPageSelectorItem[]>;
-    type: string;
-    query: string;
 }
 
 export interface DotSimpleURL {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
@@ -1,13 +1,14 @@
 import { DotPageAsset } from '../service/dot-page-selector.service';
 import { Site } from '@dotcms/dotcms-js';
+import { Observable } from 'rxjs';
 
-export interface DotPageSeletorItem {
+export interface DotPageSelectorItem {
     label: string;
-    payload: DotPageAsset | Site;
+    payload: DotPageAsset | Site | DotFolder;
 }
 
 export interface DotPageSelectorResults {
-    data: DotPageSeletorItem[];
+    data: Observable<DotPageSelectorItem[]>;
     type: string;
     query: string;
 }
@@ -15,4 +16,9 @@ export interface DotPageSelectorResults {
 export interface DotSimpleURL {
     host: string;
     pathname: string;
+}
+
+export interface DotFolder {
+    hostname: string;
+    path: string;
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
@@ -14,4 +14,5 @@ export interface DotSimpleURL {
 export interface DotFolder {
     hostname: string;
     path: string;
+    addChildrenAllowed: boolean;
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/models/dot-page-selector.models.ts
@@ -12,7 +12,7 @@ export interface DotSimpleURL {
 }
 
 export interface DotFolder {
-    hostname: string;
+    hostName: string;
     path: string;
     addChildrenAllowed: boolean;
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.spec.ts
@@ -1,5 +1,4 @@
 import { DotPageAsset, DotPageSelectorService } from './dot-page-selector.service';
-import { mockDotPageSelectorResults } from '../dot-page-selector.component.spec';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, getTestBed } from '@angular/core/testing';
 import { CoreWebService, Site } from '@dotcms/dotcms-js';
@@ -89,12 +88,12 @@ const expectedFolderMap: DotPageSelectorItem[] = [
 const mockGetPagedResponse = {
     entity: [
         {
-            hostname: 'demo.dotcms.com',
+            hostName: 'demo.dotcms.com',
             path: '/activities/hiking',
             identifier: 'abc'
         },
         {
-            hostname: 'lunik',
+            hostName: 'lunik',
             path: '/activities/walk',
             identifier: '123'
         }
@@ -103,11 +102,11 @@ const mockGetPagedResponse = {
 
 const expectedPagesMap: DotPageSelectorItem[] = [
     {
-        label: `//${mockGetPagedResponse.entity[0].hostname}${mockGetPagedResponse.entity[0].path}`,
+        label: `//${mockGetPagedResponse.entity[0].hostName}${mockGetPagedResponse.entity[0].path}`,
         payload: (mockGetPagedResponse.entity[0] as unknown) as DotPageAsset
     },
     {
-        label: `//${mockGetPagedResponse.entity[1].hostname}${mockGetPagedResponse.entity[1].path}`,
+        label: `//${mockGetPagedResponse.entity[1].hostName}${mockGetPagedResponse.entity[1].path}`,
         payload: (mockGetPagedResponse.entity[1] as unknown) as DotPageAsset
     }
 ];
@@ -142,21 +141,21 @@ fdescribe('DotPageSelectorService', () => {
 
         dotPageSelectorService.getPageById(searchParam).subscribe((res: any) => {
             expect(res).toEqual({
-                label: '//demo.dotcms.com/about-us',
-                payload: mockDotPageSelectorResults.data[0].payload
+                label: `//${mockGetPagedResponse.entity[0].hostName}${mockGetPagedResponse.entity[0].path}`,
+                payload: mockGetPagedResponse.entity[0]
             });
         });
 
         const req = httpMock.expectOne('/api/es/search');
-        expect(req.request.method).toBe('POST');
+        expect(req.request.method).toEqual('POST');
         expect(req.request.body).toEqual(query);
-        req.flush({ contentlets: [mockDotPageSelectorResults.data[0].payload] });
+        req.flush({ contentlets: [mockGetPagedResponse.entity[0]] });
     });
 
     it('should make page search', () => {
         dotPageSelectorService.getPages('about-us').subscribe((res: DotPageSelectorItem[]) => {
             expect(res).toEqual(expectedPagesMap);
-            expect(req.request.method).toBe('GET');
+            expect(req.request.method).toEqual('GET');
         });
 
         const req = httpMock.expectOne(
@@ -166,11 +165,11 @@ fdescribe('DotPageSelectorService', () => {
         req.flush(mockGetPagedResponse);
     });
 
-    it('should make page folder', () => {
+    it('should make page folder search', () => {
         dotPageSelectorService.getFolders('folder').subscribe((res: any) => {
             expect(res).toEqual(expectedFolderMap);
-            expect(req.request.body).toBe({ path: 'folder' });
-            expect(req.request.method).toBe('POST');
+            expect(req.request.body).toEqual({ path: 'folder' });
+            expect(req.request.method).toEqual('POST');
         });
 
         const req = httpMock.expectOne(`/api/v1/folder/byPath`);
@@ -181,7 +180,7 @@ fdescribe('DotPageSelectorService', () => {
     it('should make a host search', () => {
         dotPageSelectorService.getSites('//demo.dotcms.com').subscribe((res: any) => {
             expect(res).toEqual(expectedSitesMap);
-            expect(req.request.method).toBe('POST');
+            expect(req.request.method).toEqual('POST');
             expect(req.request.body).toEqual(hostQuery);
         });
 
@@ -199,12 +198,10 @@ fdescribe('DotPageSelectorService', () => {
     });
 
     it('should make a host search but limit to MAX_RESULTS_SIZE if string is empty', () => {
-        dotPageSelectorService.getSites('//').subscribe((res: any) => {
-            expect(req.request.body).toEqual(emptyHostQuery);
-        });
-
+        dotPageSelectorService.getSites('').subscribe();
         const req = httpMock.expectOne(`/api/es/search`);
 
+        expect(req.request.body).toEqual(emptyHostQuery);
         req.flush(mockGetSitesResponse);
     });
 

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.spec.ts
@@ -1,12 +1,13 @@
-import { DotPageSelectorService } from './dot-page-selector.service';
-import {
-    mockDotPageSelectorResults,
-    mockDotSiteSelectorResults
-} from '../dot-page-selector.component.spec';
+import { DotPageAsset, DotPageSelectorService } from './dot-page-selector.service';
+import { mockDotPageSelectorResults } from '../dot-page-selector.component.spec';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, getTestBed } from '@angular/core/testing';
-import { CoreWebService } from '@dotcms/dotcms-js';
+import { CoreWebService, Site } from '@dotcms/dotcms-js';
 import { CoreWebServiceMock } from '@tests/core-web.service.mock';
+import {
+    DotFolder,
+    DotPageSelectorItem
+} from '@components/_common/dot-page-selector/models/dot-page-selector.models';
 
 const MAX_RESULTS_SIZE = 20;
 
@@ -35,10 +36,83 @@ const hostSpecificQuery = {
     }
 };
 
-export const mockEmptyHostDotSiteSelectorResults = Object.assign({}, mockDotSiteSelectorResults);
-mockEmptyHostDotSiteSelectorResults.query = '';
+const mockGetSitesResponse = {
+    contentlets: [
+        {
+            hostname: 'demo.dotcms.com',
+            type: 'host',
+            identifier: 'abc'
+        },
+        {
+            hostname: 'lunik',
+            type: 'host',
+            identifier: '123'
+        }
+    ]
+};
 
-describe('DotPageSelectorService', () => {
+const expectedSitesMap: DotPageSelectorItem[] = [
+    {
+        label: `//${mockGetSitesResponse.contentlets[0].hostname}/`,
+        payload: mockGetSitesResponse.contentlets[0] as Site
+    },
+    {
+        label: `//${mockGetSitesResponse.contentlets[1].hostname}/`,
+        payload: mockGetSitesResponse.contentlets[1] as Site
+    }
+];
+
+const mockGetFolderResponse = {
+    entity: [
+        {
+            hostname: 'demo.dotcms.com',
+            path: '/activities/'
+        },
+        {
+            hostname: 'lunik',
+            path: '/images/'
+        }
+    ]
+};
+
+const expectedFolderMap: DotPageSelectorItem[] = [
+    {
+        label: `//${mockGetFolderResponse.entity[0].hostname}${mockGetFolderResponse.entity[0].path}`,
+        payload: mockGetFolderResponse.entity[0] as DotFolder
+    },
+    {
+        label: `//${mockGetFolderResponse.entity[1].hostname}${mockGetFolderResponse.entity[1].path}`,
+        payload: mockGetFolderResponse.entity[1] as DotFolder
+    }
+];
+
+const mockGetPagedResponse = {
+    entity: [
+        {
+            hostname: 'demo.dotcms.com',
+            path: '/activities/hiking',
+            identifier: 'abc'
+        },
+        {
+            hostname: 'lunik',
+            path: '/activities/walk',
+            identifier: '123'
+        }
+    ]
+};
+
+const expectedPagesMap: DotPageSelectorItem[] = [
+    {
+        label: `//${mockGetPagedResponse.entity[0].hostname}${mockGetPagedResponse.entity[0].path}`,
+        payload: (mockGetPagedResponse.entity[0] as unknown) as DotPageAsset
+    },
+    {
+        label: `//${mockGetPagedResponse.entity[1].hostname}${mockGetPagedResponse.entity[1].path}`,
+        payload: (mockGetPagedResponse.entity[1] as unknown) as DotPageAsset
+    }
+];
+
+fdescribe('DotPageSelectorService', () => {
     let injector: TestBed;
     let dotPageSelectorService: DotPageSelectorService;
     let httpMock: HttpTestingController;
@@ -80,108 +154,58 @@ describe('DotPageSelectorService', () => {
     });
 
     it('should make page search', () => {
-        dotPageSelectorService.setCurrentHost({
-            hostname: 'random',
-            type: 'n/a',
-            identifier: '1',
-            archived: false
-        });
-
-        dotPageSelectorService.search('about-us').subscribe((res: any) => {
-            expect(res).toEqual(mockDotPageSelectorResults);
+        dotPageSelectorService.getPages('about-us').subscribe((res: DotPageSelectorItem[]) => {
+            expect(res).toEqual(expectedPagesMap);
+            expect(req.request.method).toBe('GET');
         });
 
         const req = httpMock.expectOne(
             `v1/page/search?path=about-us&onlyLiveSites=true&live=false`
         );
-        expect(req.request.method).toBe('GET');
-        req.flush({ entity: [mockDotPageSelectorResults.data[0].payload] });
+
+        req.flush(mockGetPagedResponse);
+    });
+
+    it('should make page folder', () => {
+        dotPageSelectorService.getFolders('folder').subscribe((res: any) => {
+            expect(res).toEqual(expectedFolderMap);
+            expect(req.request.body).toBe({ path: 'folder' });
+            expect(req.request.method).toBe('POST');
+        });
+
+        const req = httpMock.expectOne(`/api/v1/folder/byPath`);
+
+        req.flush(mockGetFolderResponse);
     });
 
     it('should make a host search', () => {
-        dotPageSelectorService.search('//demo.dotcms.com').subscribe((res: any) => {
-            expect(res).toEqual(mockDotSiteSelectorResults);
+        dotPageSelectorService.getSites('//demo.dotcms.com').subscribe((res: any) => {
+            expect(res).toEqual(expectedSitesMap);
+            expect(req.request.method).toBe('POST');
+            expect(req.request.body).toEqual(hostQuery);
         });
 
         const req = httpMock.expectOne(`/api/es/search`);
-        expect(req.request.method).toBe('POST');
-        expect(req.request.body).toEqual(hostQuery);
-        req.flush({ contentlets: [mockDotSiteSelectorResults.data[0].payload] });
+
+        req.flush(mockGetSitesResponse);
+    });
+
+    it('should make specific host search', () => {
+        dotPageSelectorService.getSites('//demo.dotcms.com', true).subscribe((res: any) => {
+            expect(req.request.body).toEqual(hostSpecificQuery);
+        });
+        const req = httpMock.expectOne(`/api/es/search`);
+        req.flush(mockGetSitesResponse);
     });
 
     it('should make a host search but limit to MAX_RESULTS_SIZE if string is empty', () => {
-        dotPageSelectorService.search('//').subscribe((res: any) => {
-            expect(res).toEqual(mockEmptyHostDotSiteSelectorResults);
+        dotPageSelectorService.getSites('//').subscribe((res: any) => {
+            expect(req.request.body).toEqual(emptyHostQuery);
         });
 
         const req = httpMock.expectOne(`/api/es/search`);
-        expect(req.request.method).toBe('POST');
-        expect(req.request.body).toEqual(emptyHostQuery);
-        req.flush({ contentlets: [mockDotSiteSelectorResults.data[0].payload] });
-    });
 
-    it('should make host and page search (Full Search)', () => {
-        dotPageSelectorService.search('//demo.dotcms.com/about-us').subscribe((res: any) => {
-            expect(res).toEqual(mockDotPageSelectorResults);
-        });
-
-        const req = httpMock.expectOne(`/api/es/search`);
-        expect(req.request.method).toBe('POST');
-        expect(req.request.body).toEqual(hostSpecificQuery);
-        req.flush({ contentlets: [mockDotSiteSelectorResults.data[0].payload] });
-
-        const req2 = httpMock.expectOne(
-            'v1/page/search?path=//demo.dotcms.com/about-us&onlyLiveSites=true&live=false'
-        );
-        expect(req2.request.method).toBe('GET');
-        req2.flush({ entity: [mockDotPageSelectorResults.data[0].payload] });
-    });
-
-    it('should return empty results on Full Search if host is invalid', () => {
-        dotPageSelectorService.search('//demo.dotcms.com/about-us').subscribe((res: any) => {
-            expect(res).toEqual({
-                data: [],
-                query: 'demo.dotcms.com',
-                type: 'site'
-            });
-        });
-
-        const req = httpMock.expectOne(`/api/es/search`);
-        expect(req.request.method).toBe('POST');
-        expect(req.request.body).toEqual(hostSpecificQuery);
-        req.flush({ contentlets: [] });
-    });
-
-    it('should return empty results when host is invalid', () => {
-        dotPageSelectorService.search('//demo.dotcms.com').subscribe((res: any) => {
-            expect(res).toEqual({
-                data: [],
-                query: 'demo.dotcms.com',
-                type: 'site'
-            });
-        });
-
-        const req = httpMock.expectOne(`/api/es/search`);
-        expect(req.request.method).toBe('POST');
-        expect(req.request.body).toEqual(hostQuery);
-        req.flush({ contentlets: [] });
-    });
-
-    it('should return empty results when page is invalid', () => {
-        const searchParam = 'invalidPage';
-        dotPageSelectorService.search(searchParam).subscribe((res: any) => {
-            expect(res).toEqual({
-                data: [],
-                query: 'invalidPage',
-                type: 'page'
-            });
-        });
-
-        const req = httpMock.expectOne(
-            'v1/page/search?path=invalidPage&onlyLiveSites=true&live=false'
-        );
-        expect(req.request.method).toBe('GET');
-        req.flush({ entity: [] });
+        req.flush(mockGetSitesResponse);
     });
 
     afterEach(() => {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.spec.ts
@@ -50,7 +50,7 @@ const mockGetSitesResponse = {
     ]
 };
 
-const expectedSitesMap: DotPageSelectorItem[] = [
+export const expectedSitesMap: DotPageSelectorItem[] = [
     {
         label: `//${mockGetSitesResponse.contentlets[0].hostname}/`,
         payload: mockGetSitesResponse.contentlets[0] as Site
@@ -64,23 +64,25 @@ const expectedSitesMap: DotPageSelectorItem[] = [
 const mockGetFolderResponse = {
     entity: [
         {
-            hostname: 'demo.dotcms.com',
-            path: '/activities/'
+            hostName: 'demo.dotcms.com',
+            path: '/activities/',
+            addChildrenAllowed: true
         },
         {
-            hostname: 'lunik',
-            path: '/images/'
+            hostName: 'lunik',
+            path: '/images/',
+            addChildrenAllowed: false
         }
     ]
 };
 
-const expectedFolderMap: DotPageSelectorItem[] = [
+export const expectedFolderMap: DotPageSelectorItem[] = [
     {
-        label: `//${mockGetFolderResponse.entity[0].hostname}${mockGetFolderResponse.entity[0].path}`,
+        label: `//${mockGetFolderResponse.entity[0].hostName}${mockGetFolderResponse.entity[0].path}`,
         payload: mockGetFolderResponse.entity[0] as DotFolder
     },
     {
-        label: `//${mockGetFolderResponse.entity[1].hostname}${mockGetFolderResponse.entity[1].path}`,
+        label: `//${mockGetFolderResponse.entity[1].hostName}${mockGetFolderResponse.entity[1].path}`,
         payload: mockGetFolderResponse.entity[1] as DotFolder
     }
 ];
@@ -100,7 +102,7 @@ const mockGetPagedResponse = {
     ]
 };
 
-const expectedPagesMap: DotPageSelectorItem[] = [
+export const expectedPagesMap: DotPageSelectorItem[] = [
     {
         label: `//${mockGetPagedResponse.entity[0].hostName}${mockGetPagedResponse.entity[0].path}`,
         payload: (mockGetPagedResponse.entity[0] as unknown) as DotPageAsset
@@ -111,7 +113,7 @@ const expectedPagesMap: DotPageSelectorItem[] = [
     }
 ];
 
-fdescribe('DotPageSelectorService', () => {
+describe('DotPageSelectorService', () => {
     let injector: TestBed;
     let dotPageSelectorService: DotPageSelectorService;
     let httpMock: HttpTestingController;

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
@@ -1,13 +1,8 @@
-import { map, pluck, flatMap, toArray, switchMap, take, mergeMap } from 'rxjs/operators';
+import { map, pluck, flatMap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Site, CoreWebService } from '@dotcms/dotcms-js';
-import {
-    DotFolder,
-    DotPageSelectorItem,
-    DotPageSelectorResults,
-    DotSimpleURL
-} from '../models/dot-page-selector.models';
+import { DotFolder, DotPageSelectorItem } from '../models/dot-page-selector.models';
 
 export interface DotPageAsset {
     template: string;
@@ -35,15 +30,11 @@ export interface DotPageAsset {
     url?: string;
 }
 
-const HOST_FULL_REGEX = /^\/\/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b\//;
 const PAGE_BASE_TYPE_QUERY = '+basetype:5';
 const MAX_RESULTS_SIZE = 20;
 
 @Injectable()
 export class DotPageSelectorService {
-    // private currentHost: Site;
-    // private isFolderSearch: boolean;
-
     constructor(private coreWebService: CoreWebService) {}
 
     /**
@@ -73,66 +64,6 @@ export class DotPageSelectorService {
                 })
             );
     }
-    //
-    // /**
-    //  * Set the host to perform page searches
-    //  *
-    //  * @param {Site} host
-    //  * @memberof DotPageSelectorService
-    //  */
-    // setCurrentHost(host: Site): void {
-    //     this.currentHost = host;
-    // }
-    //
-    // /**
-    //  * Set if the search is for folders
-    //  *
-    //  * @param {boolean} isFolderSearch
-    //  * @memberof DotPageSelectorService
-    //  */
-    // setFolderSearch(isFolderSearch: boolean): void {
-    //     this.isFolderSearch = isFolderSearch;
-    // }
-
-    // /**
-    //  * Search for host, page or both
-    //  *
-    //  * @param {string} param
-    //  * @returns {Observable<DotPageSelectorResults>}
-    //  * @memberof DotPageSelectorService
-    //  */
-    // search(param: string): Observable<DotPageSelectorResults> {
-    //     debugger;
-    //     if (this.isTwoStepSearch(param)) {
-    //         return this.fullSearch(param);
-    //     } else {
-    //         return this.conditionalSearch(param);
-    //     }
-    // }
-
-    // private conditionalSearch(param: string): Observable<DotPageSelectorResults> {
-    //     debugger;
-    //     return this.shouldSearchPages(param)
-    //         ? this.isFolderSearch
-    //             ? this.getFolders(param)
-    //             : this.getPages(param)
-    //         : this.getSites(this.getSiteName(param));
-    // }
-    //
-    // private fullSearch(param: string): Observable<DotPageSelectorResults> {
-    //     const host = this.parseUrl(param).host;
-    //     return this.getSites(host, true).pipe(
-    //         take(1),
-    //         switchMap((results: DotPageSelectorResults) => {
-    //             if (results.data.length) {
-    //                 this.setCurrentHost(<Site>results.data[0].payload);
-    //                 return this.isFolderSearch ? this.getFolders(param) : this.getPages(param);
-    //             } else {
-    //                 return of(results);
-    //             }
-    //         })
-    //     );
-    // }
 
     getPages(path: string): Observable<DotPageSelectorItem[]> {
         return this.coreWebService
@@ -172,20 +103,6 @@ export class DotPageSelectorService {
             );
     }
 
-    private getRequestBodyQuery(query: string, size?: number): { [key: string]: {} } {
-        let obj = {
-            query: {
-                query_string: {
-                    query: query
-                }
-            }
-        };
-        if (size) {
-            obj = Object.assign(obj, { size: size });
-        }
-        return obj;
-    }
-
     getSites(param: string, specific?: boolean): Observable<DotPageSelectorItem[]> {
         let query = '+contenttype:Host -identifier:SYSTEM_HOST +host.hostName:';
         query += specific ? this.getSiteName(param) : `*${this.getSiteName(param)}*`;
@@ -204,68 +121,24 @@ export class DotPageSelectorService {
                         return { payload: site, label: `//${site.hostname}/` };
                     });
                 })
-
-                //
-                // flatMap((sites: Site[]) => sites),
-                // map((site: Site) => {
-                //     return {
-                //         label: `//${site.hostname}/`,
-                //         payload: site,
-                //         isHost: true
-                //     };
-                // })
             );
+    }
+
+    private getRequestBodyQuery(query: string, size?: number): { [key: string]: {} } {
+        let obj = {
+            query: {
+                query_string: {
+                    query: query
+                }
+            }
+        };
+        if (size) {
+            obj = Object.assign(obj, { size: size });
+        }
+        return obj;
     }
 
     private getSiteName(site: string): string {
         return site.replace(/\//g, '');
     }
-
-    // private isHostAndPath(param: string): boolean {
-    //     const url: DotSimpleURL | { [key: string]: string } = this.parseUrl(param);
-    //     return url && !!(url.host && url.pathname.length > 0);
-    // }
-    //
-    // private isReSearchingForHost(query: string): boolean {
-    //     return this.isSearchingForHost(query) && this.hostChanged(query);
-    // }
-
-    // private hostChanged(query: string): boolean {
-    //     const parsedURL = this.parseUrl(query);
-    //     return (
-    //         this.currentHost &&
-    //         parsedURL &&
-    //         this.currentHost.hostname.toLocaleLowerCase() !== parsedURL.host.toLocaleLowerCase()
-    //     );
-    // }
-
-    // private isSearchingForHost(query: string): boolean {
-    //     return query.startsWith('//');
-    // }
-
-    // private isTwoStepSearch(param): boolean {
-    //     return this.isHostAndPath(param) && (!this.currentHost || this.hostChanged(param));
-    // }
-
-    // private parseUrl(query: string): DotSimpleURL {
-    //     if (this.isSearchingForHost(query)) {
-    //         try {
-    //             const url = new URL(`http:${query}`);
-    //             return { host: url.host, pathname: url.pathname.substr(1) };
-    //         } catch {
-    //             return null;
-    //         }
-    //     } else {
-    //         return null;
-    //     }
-    // }
-
-    // private shouldSearchPages(query: string): boolean {
-    //     debugger;
-    //     if (!this.isHostAndPath(query) || this.isReSearchingForHost(query)) {
-    //         this.currentHost = null;
-    //     }
-    //
-    //     return !!(this.currentHost || !this.isSearchingForHost(query));
-    // }
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
@@ -56,12 +56,7 @@ export class DotPageSelectorService {
             .pipe(
                 pluck('contentlets'),
                 flatMap((pages: DotPageAsset[]) => pages),
-                map((page: DotPageAsset) => {
-                    return {
-                        label: `//${page.hostName}${page.path}`,
-                        payload: page
-                    };
-                })
+                map((page: DotPageAsset) => this.getPageSelectorItem(page))
             );
     }
 
@@ -73,12 +68,7 @@ export class DotPageSelectorService {
             .pipe(
                 pluck('entity'),
                 map((pages: DotPageAsset[]) => {
-                    return pages.map((page) => {
-                        return {
-                            label: `//${page.hostName}${page.path}`,
-                            payload: page
-                        };
-                    });
+                    return pages.map((page: DotPageAsset) => this.getPageSelectorItem(page));
                 })
             );
     }
@@ -93,12 +83,7 @@ export class DotPageSelectorService {
             .pipe(
                 pluck('entity'),
                 map((folder: DotFolder[]) => {
-                    return folder.map((folder: DotFolder) => {
-                        return {
-                            label: `//${folder.hostname}${folder.path}`,
-                            payload: folder
-                        };
-                    });
+                    return folder.map((folder: DotFolder) => this.getPageSelectorItem(folder));
                 })
             );
     }
@@ -140,5 +125,12 @@ export class DotPageSelectorService {
 
     private getSiteName(site: string): string {
         return site.replace(/\//g, '');
+    }
+
+    private getPageSelectorItem(item: DotPageAsset | DotFolder): DotPageSelectorItem {
+        return {
+            label: `//${item.hostName}${item.path}`,
+            payload: item
+        };
     }
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
@@ -46,7 +46,7 @@ export class DotPageSelectorService {
      */
     getPageById(identifier: string): Observable<DotPageSelectorItem> {
         return this.coreWebService
-            .requestView({
+            .requestView<DotPageAsset[]>({
                 body: this.getRequestBodyQuery(
                     `${PAGE_BASE_TYPE_QUERY} +identifier:*${identifier}*`
                 ),
@@ -67,7 +67,7 @@ export class DotPageSelectorService {
 
     getPages(path: string): Observable<DotPageSelectorItem[]> {
         return this.coreWebService
-            .requestView({
+            .requestView<DotPageAsset[]>({
                 url: `v1/page/search?path=${path}&onlyLiveSites=true&live=false`
             })
             .pipe(
@@ -85,7 +85,7 @@ export class DotPageSelectorService {
 
     getFolders(path: string): Observable<DotPageSelectorItem[]> {
         return this.coreWebService
-            .requestView({
+            .requestView<DotFolder[]>({
                 url: `/api/v1/folder/byPath`,
                 body: { path: path },
                 method: 'POST'
@@ -107,7 +107,7 @@ export class DotPageSelectorService {
         let query = '+contenttype:Host -identifier:SYSTEM_HOST +host.hostName:';
         query += specific ? this.getSiteName(param) : `*${this.getSiteName(param)}*`;
         return this.coreWebService
-            .requestView({
+            .requestView<Site[]>({
                 body: param
                     ? this.getRequestBodyQuery(query)
                     : this.getRequestBodyQuery(query, MAX_RESULTS_SIZE),

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
@@ -1,9 +1,10 @@
-import { map, pluck, flatMap, toArray, switchMap, take } from 'rxjs/operators';
+import { map, pluck, flatMap, toArray, switchMap, take, mergeMap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { Site, CoreWebService } from '@dotcms/dotcms-js';
 import {
-    DotPageSeletorItem,
+    DotFolder,
+    DotPageSelectorItem,
     DotPageSelectorResults,
     DotSimpleURL
 } from '../models/dot-page-selector.models';
@@ -40,7 +41,8 @@ const MAX_RESULTS_SIZE = 20;
 
 @Injectable()
 export class DotPageSelectorService {
-    private currentHost: Site;
+    // private currentHost: Site;
+    // private isFolderSearch: boolean;
 
     constructor(private coreWebService: CoreWebService) {}
 
@@ -48,10 +50,10 @@ export class DotPageSelectorService {
      * Get page asset by identifier
      *
      * @param {string} identifier
-     * @returns {Observable<DotPageSeletorItem>}
+     * @returns {Observable<DotPageSelectorItem>}
      * @memberof DotPageSelectorService
      */
-    getPageById(identifier: string): Observable<DotPageSeletorItem> {
+    getPageById(identifier: string): Observable<DotPageSelectorItem> {
         return this.coreWebService
             .requestView({
                 body: this.getRequestBodyQuery(
@@ -71,74 +73,101 @@ export class DotPageSelectorService {
                 })
             );
     }
+    //
+    // /**
+    //  * Set the host to perform page searches
+    //  *
+    //  * @param {Site} host
+    //  * @memberof DotPageSelectorService
+    //  */
+    // setCurrentHost(host: Site): void {
+    //     this.currentHost = host;
+    // }
+    //
+    // /**
+    //  * Set if the search is for folders
+    //  *
+    //  * @param {boolean} isFolderSearch
+    //  * @memberof DotPageSelectorService
+    //  */
+    // setFolderSearch(isFolderSearch: boolean): void {
+    //     this.isFolderSearch = isFolderSearch;
+    // }
 
-    /**
-     * Set the host to perform page searches
-     *
-     * @param {Site} host
-     * @memberof DotPageSelectorService
-     */
-    setCurrentHost(host: Site): void {
-        this.currentHost = host;
-    }
+    // /**
+    //  * Search for host, page or both
+    //  *
+    //  * @param {string} param
+    //  * @returns {Observable<DotPageSelectorResults>}
+    //  * @memberof DotPageSelectorService
+    //  */
+    // search(param: string): Observable<DotPageSelectorResults> {
+    //     debugger;
+    //     if (this.isTwoStepSearch(param)) {
+    //         return this.fullSearch(param);
+    //     } else {
+    //         return this.conditionalSearch(param);
+    //     }
+    // }
 
-    /**
-     * Search for host, page or both
-     *
-     * @param {string} param
-     * @returns {Observable<DotPageSelectorResults>}
-     * @memberof DotPageSelectorService
-     */
-    search(param: string): Observable<DotPageSelectorResults> {
-        if (this.isTwoStepSearch(param)) {
-            return this.fullSearch(param);
-        } else {
-            return this.conditionalSearch(param);
-        }
-    }
+    // private conditionalSearch(param: string): Observable<DotPageSelectorResults> {
+    //     debugger;
+    //     return this.shouldSearchPages(param)
+    //         ? this.isFolderSearch
+    //             ? this.getFolders(param)
+    //             : this.getPages(param)
+    //         : this.getSites(this.getSiteName(param));
+    // }
+    //
+    // private fullSearch(param: string): Observable<DotPageSelectorResults> {
+    //     const host = this.parseUrl(param).host;
+    //     return this.getSites(host, true).pipe(
+    //         take(1),
+    //         switchMap((results: DotPageSelectorResults) => {
+    //             if (results.data.length) {
+    //                 this.setCurrentHost(<Site>results.data[0].payload);
+    //                 return this.isFolderSearch ? this.getFolders(param) : this.getPages(param);
+    //             } else {
+    //                 return of(results);
+    //             }
+    //         })
+    //     );
+    // }
 
-    private conditionalSearch(param: string): Observable<DotPageSelectorResults> {
-        return this.shouldSearchPages(param)
-            ? this.getPages(param)
-            : this.getSites(this.getSiteName(param));
-    }
-
-    private fullSearch(param: string): Observable<DotPageSelectorResults> {
-        const host = this.parseUrl(param).host;
-        return this.getSites(host, true).pipe(
-            take(1),
-            switchMap((results: DotPageSelectorResults) => {
-                if (results.data.length) {
-                    this.setCurrentHost(<Site>results.data[0].payload);
-                    return this.getPages(param);
-                } else {
-                    return of(results);
-                }
-            })
-        );
-    }
-
-    private getPages(path: string): Observable<DotPageSelectorResults> {
+    getPages(path: string): Observable<DotPageSelectorItem[]> {
         return this.coreWebService
             .requestView({
                 url: `v1/page/search?path=${path}&onlyLiveSites=true&live=false`
             })
             .pipe(
                 pluck('entity'),
-                flatMap((pages: DotPageAsset[]) => pages),
-                map((page: DotPageAsset) => {
-                    return {
-                        label: `//${page.hostName}${page.path}`,
-                        payload: page
-                    };
-                }),
-                toArray(),
-                map((items: DotPageSeletorItem[]) => {
-                    return {
-                        data: items,
-                        type: 'page',
-                        query: path.replace(HOST_FULL_REGEX, '')
-                    };
+                map((pages: DotPageAsset[]) => {
+                    return pages.map((page) => {
+                        return {
+                            label: `//${page.hostName}${page.path}`,
+                            payload: page
+                        };
+                    });
+                })
+            );
+    }
+
+    getFolders(path: string): Observable<DotPageSelectorItem[]> {
+        return this.coreWebService
+            .requestView({
+                url: `/api/v1/folder/byPath`,
+                body: { path: path },
+                method: 'POST'
+            })
+            .pipe(
+                pluck('entity'),
+                map((folder: DotFolder[]) => {
+                    return folder.map((folder: DotFolder) => {
+                        return {
+                            label: `//${folder.hostname}${folder.path}`,
+                            payload: folder
+                        };
+                    });
                 })
             );
     }
@@ -157,7 +186,7 @@ export class DotPageSelectorService {
         return obj;
     }
 
-    private getSites(param: string, specific?: boolean): Observable<DotPageSelectorResults> {
+    getSites(param: string, specific?: boolean): Observable<DotPageSelectorItem[]> {
         let query = '+contenttype:Host -identifier:SYSTEM_HOST +host.hostName:';
         query += specific ? this.getSiteName(param) : `*${this.getSiteName(param)}*`;
         return this.coreWebService
@@ -170,22 +199,21 @@ export class DotPageSelectorService {
             })
             .pipe(
                 pluck('contentlets'),
-                flatMap((sites: Site[]) => sites),
-                map((site: Site) => {
-                    return {
-                        label: `//${site.hostname}/`,
-                        payload: site,
-                        isHost: true
-                    };
-                }),
-                toArray(),
-                map((items: DotPageSeletorItem[]) => {
-                    return {
-                        data: items,
-                        type: 'site',
-                        query: param
-                    };
+                map((sites: Site[]) => {
+                    return sites.map((site) => {
+                        return { payload: site, label: `//${site.hostname}/` };
+                    });
                 })
+
+                //
+                // flatMap((sites: Site[]) => sites),
+                // map((site: Site) => {
+                //     return {
+                //         label: `//${site.hostname}/`,
+                //         payload: site,
+                //         isHost: true
+                //     };
+                // })
             );
     }
 
@@ -193,50 +221,51 @@ export class DotPageSelectorService {
         return site.replace(/\//g, '');
     }
 
-    private isHostAndPath(param: string): boolean {
-        const url: DotSimpleURL | { [key: string]: string } = this.parseUrl(param);
-        return url && !!(url.host && url.pathname.length > 0);
-    }
+    // private isHostAndPath(param: string): boolean {
+    //     const url: DotSimpleURL | { [key: string]: string } = this.parseUrl(param);
+    //     return url && !!(url.host && url.pathname.length > 0);
+    // }
+    //
+    // private isReSearchingForHost(query: string): boolean {
+    //     return this.isSearchingForHost(query) && this.hostChanged(query);
+    // }
 
-    private isReSearchingForHost(query: string): boolean {
-        return this.isSearchingForHost(query) && this.hostChanged(query);
-    }
+    // private hostChanged(query: string): boolean {
+    //     const parsedURL = this.parseUrl(query);
+    //     return (
+    //         this.currentHost &&
+    //         parsedURL &&
+    //         this.currentHost.hostname.toLocaleLowerCase() !== parsedURL.host.toLocaleLowerCase()
+    //     );
+    // }
 
-    private hostChanged(query: string): boolean {
-        const parsedURL = this.parseUrl(query);
-        return (
-            this.currentHost &&
-            parsedURL &&
-            this.currentHost.hostname.toLocaleLowerCase() !== parsedURL.host.toLocaleLowerCase()
-        );
-    }
+    // private isSearchingForHost(query: string): boolean {
+    //     return query.startsWith('//');
+    // }
 
-    private isSearchingForHost(query: string): boolean {
-        return query.startsWith('//');
-    }
+    // private isTwoStepSearch(param): boolean {
+    //     return this.isHostAndPath(param) && (!this.currentHost || this.hostChanged(param));
+    // }
 
-    private isTwoStepSearch(param): boolean {
-        return this.isHostAndPath(param) && (!this.currentHost || this.hostChanged(param));
-    }
+    // private parseUrl(query: string): DotSimpleURL {
+    //     if (this.isSearchingForHost(query)) {
+    //         try {
+    //             const url = new URL(`http:${query}`);
+    //             return { host: url.host, pathname: url.pathname.substr(1) };
+    //         } catch {
+    //             return null;
+    //         }
+    //     } else {
+    //         return null;
+    //     }
+    // }
 
-    private parseUrl(query: string): DotSimpleURL {
-        if (this.isSearchingForHost(query)) {
-            try {
-                const url = new URL(`http:${query}`);
-                return { host: url.host, pathname: url.pathname.substr(1) };
-            } catch {
-                return null;
-            }
-        } else {
-            return null;
-        }
-    }
-
-    private shouldSearchPages(query: string): boolean {
-        if (!this.isHostAndPath(query) || this.isReSearchingForHost(query)) {
-            this.currentHost = null;
-        }
-
-        return !!(this.currentHost || !this.isSearchingForHost(query));
-    }
+    // private shouldSearchPages(query: string): boolean {
+    //     debugger;
+    //     if (!this.isHostAndPath(query) || this.isReSearchingForHost(query)) {
+    //         this.currentHost = null;
+    //     }
+    //
+    //     return !!(this.currentHost || !this.isSearchingForHost(query));
+    // }
 }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
@@ -184,7 +184,6 @@ export class DotWizardComponent implements OnInit, OnDestroy {
     }
 
     private sendValue(): void {
-        debugger;
         this.dotWizardService.output$(this.wizardData);
         this.close();
     }

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
@@ -184,6 +184,7 @@ export class DotWizardComponent implements OnInit, OnDestroy {
     }
 
     private sendValue(): void {
+        debugger;
         this.dotWizardService.output$(this.wizardData);
         this.close();
     }

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
@@ -31,7 +31,6 @@
         <dot-page-selector
             formControlName="move"
             [folderSearch]="true"
-            [floatingLabel]="true"
             [label]="'Move' | dm"
         ></dot-page-selector>
     </div>

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
@@ -29,7 +29,7 @@
 
     <div class="p-field" *ngIf="data['moveable']" >
         <dot-page-selector
-            formControlName="move"
+            formControlName="pathToMove"
             [folderSearch]="true"
             [label]="'Move' | dm"
         ></dot-page-selector>

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
@@ -26,4 +26,15 @@
         >
         </textarea>
     </div>
+
+    <div class="p-field" *ngIf="data['moveable']" >
+        <dot-page-selector
+            formControlName="move"
+            [folderSearch]="true"
+            [floatingLabel]="true"
+            [label]="'Move' | dm"
+        ></dot-page-selector>
+    </div>
+
+
 </form>

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.spec.ts
@@ -95,7 +95,8 @@ describe('DotAssigneeFormComponent', () => {
         it('should emit value and valid on form change', () => {
             const mockFormValue = {
                 assign: mockProcessedRoles[0].id,
-                comments: 'test'
+                comments: 'test',
+                move: '/path/'
             };
             const formComponent: DotCommentAndAssignFormComponent = fixture.debugElement.query(
                 By.css('dot-comment-and-assign-form')

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.spec.ts
@@ -96,7 +96,7 @@ describe('DotAssigneeFormComponent', () => {
             const mockFormValue = {
                 assign: mockProcessedRoles[0].id,
                 comments: 'test',
-                move: '/path/'
+                pathToMove: '/path/'
             };
             const formComponent: DotCommentAndAssignFormComponent = fixture.debugElement.query(
                 By.css('dot-comment-and-assign-form')

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
@@ -4,11 +4,12 @@ import { take, takeUntil } from 'rxjs/operators';
 import { DotRole } from '@models/dot-role/dot-role.model';
 import { SelectItem } from 'primeng/api';
 import { DotFormModel } from '@models/dot-form/dot-form.model';
-import { FormBuilder, FormGroup } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
 
 enum DotActionInputs {
-    ASSIGNABLE = 'assignable'
+    ASSIGNABLE = 'assignable',
+    MOVEABLE = 'moveable'
 }
 
 @Component({
@@ -59,7 +60,7 @@ export class DotCommentAndAssignFormComponent
         this.form = this.fb.group({
             assign: this.dotRoles ? this.dotRoles[0].value : '',
             comments: '',
-            move: ''
+            move: this.data[DotActionInputs.MOVEABLE] ? ['', [Validators.required]] : ''
         });
         this.emitValues();
         this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => this.emitValues());

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
@@ -60,7 +60,7 @@ export class DotCommentAndAssignFormComponent
         this.form = this.fb.group({
             assign: this.dotRoles ? this.dotRoles[0].value : '',
             comments: '',
-            move: this.data[DotActionInputs.MOVEABLE] ? ['', [Validators.required]] : ''
+            pathToMove: this.data[DotActionInputs.MOVEABLE] ? ['', [Validators.required]] : ''
         });
         this.emitValues();
         this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => this.emitValues());

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
@@ -29,7 +29,6 @@ export class DotCommentAndAssignFormComponent
     constructor(private dotRolesService: DotRolesService, public fb: FormBuilder) {}
 
     ngOnInit() {
-        debugger;
         if (this.data) {
             if (this.data[DotActionInputs.ASSIGNABLE]) {
                 this.dotRolesService

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
@@ -29,6 +29,7 @@ export class DotCommentAndAssignFormComponent
     constructor(private dotRolesService: DotRolesService, public fb: FormBuilder) {}
 
     ngOnInit() {
+        debugger;
         if (this.data) {
             if (this.data[DotActionInputs.ASSIGNABLE]) {
                 this.dotRolesService
@@ -58,7 +59,8 @@ export class DotCommentAndAssignFormComponent
     private initForm(): void {
         this.form = this.fb.group({
             assign: this.dotRoles ? this.dotRoles[0].value : '',
-            comments: ''
+            comments: '',
+            move: ''
         });
         this.emitValues();
         this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => this.emitValues());

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.module.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.module.ts
@@ -6,6 +6,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DotRolesService } from '@services/dot-roles/dot-roles.service';
 import { InputTextareaModule } from 'primeng/inputtextarea';
+import { DotPageSelectorModule } from '@components/_common/dot-page-selector/dot-page-selector.module';
 
 @NgModule({
     imports: [
@@ -14,7 +15,8 @@ import { InputTextareaModule } from 'primeng/inputtextarea';
         ReactiveFormsModule,
         DotPipesModule,
         InputTextareaModule,
-        DropdownModule
+        DropdownModule,
+        DotPageSelectorModule
     ],
     declarations: [DotCommentAndAssignFormComponent],
     exports: [DotCommentAndAssignFormComponent],

--- a/libs/dot-primeng-theme-styles/src/scss/_mixins.scss
+++ b/libs/dot-primeng-theme-styles/src/scss/_mixins.scss
@@ -76,7 +76,7 @@
 
 @mixin dot-field-helper-on-input {
     position: absolute;
-    top: $spacing-5;
+    top: $spacing-4;
     right: 0;
     z-index: 1;
 }


### PR DESCRIPTION
### Proposed Changes
* Be able to move content over the workflow wizard modal. 

### Checklist
- [X ] Tests
- [X ] Translations
- [X ] Security Implications Contemplated (add notes if applicable)

### Additional Info
Current rules for Page/Folder selector:

- a host search start with //.
- type text, will look for pages/folders
- when a host is selected should do a page/folder search right away.
- when the user type a folder that do not exist an error message should be displayed indicating a new folder will be created.
- when there are empty result an error message should be displayed
- when use user do not have permissions to move to specific folder an error message should be displayed.

Places where to test workflows in the UI:

- Content Search: right click on list item, bulk action button, selected and item and in the right buttons.
- Site Browser: right click on list item
- Edit Mode: Top right button. under Properties button at the right.
- Tasks: bulk actions button, selected and item and in the top right circular button.


