### PR TITLE
Issue 18411 drag and drop images in containers in edit mode

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -31,6 +31,7 @@ import { DotEventsService } from '@services/dot-events/dot-events.service';
 import { DotWorkflowActionsFireService } from '@services/dot-workflow-actions-fire/dot-workflow-actions-fire.service';
 import { mockResponseView } from '@dotcms/app/test/response-view.mock';
 import { HttpErrorResponse } from '@angular/common/http';
+import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 @Injectable()
 class MockDotLicenseService {
@@ -183,6 +184,7 @@ describe('DotEditContentHtmlService', () => {
                     ConfirmationService,
                     DotGlobalMessageService,
                     DotEventsService,
+                    { provide: DotHttpErrorManagerService, useValue: {} },
                     DotWorkflowActionsFireService,
                     { provide: DotMessageService, useValue: messageServiceMock },
                     { provide: DotLicenseService, useClass: MockDotLicenseService }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -19,7 +19,9 @@ import { MODEL_VAR_NAME } from '@dotcms/app/portlets/dot-edit-page/content/servi
 import { DotCMSContentType } from '@dotcms/dotcms-models';
 import { PageModelChangeEvent, PageModelChangeEventType } from './models';
 import {
+    DotAssetPayload,
     DotContentletEvent,
+    DotContentletEventDragAndDropDotAsset,
     DotContentletEventRelocate,
     DotContentletEventSave,
     DotContentletEventSelect,
@@ -38,6 +40,7 @@ export enum DotContentletAction {
 @Injectable()
 export class DotEditContentHtmlService {
     contentletEvents$: Subject<
+        | DotContentletEventDragAndDropDotAsset
         | DotContentletEventRelocate
         | DotContentletEventSelect
         | DotContentletEventSave
@@ -200,14 +203,14 @@ export class DotEditContentHtmlService {
     /**
      * Render a contentlet in the DOM after add it
      *
-     * @param * contentlet
+     * @param DotPageContent contentlet
+     * @param string placeholderIdToBeReplaced
      * @memberof DotEditContentHtmlService
      */
-    renderAddedContentlet(contentlet: DotPageContent, externalPlaceholderId?: string): void {
+    renderAddedContentlet(contentlet: DotPageContent, placeholderIdToBeReplaced?: string): void {
         const doc = this.getEditPageDocument();
-
-        if (externalPlaceholderId) {
-            const container: HTMLElement = doc.querySelector(`#${externalPlaceholderId}`).closest('[data-dot-object="container"]');
+        if (placeholderIdToBeReplaced) {
+            const container: HTMLElement = doc.querySelector(`#${placeholderIdToBeReplaced}`).closest('[data-dot-object="container"]');
             this.setContainterToAppendContentlet({ identifier: container.dataset['dotIdentifier'], uuid: container.dataset['dotUuid']});
         }
 
@@ -219,13 +222,14 @@ export class DotEditContentHtmlService {
             this.showContentAlreadyAddedError();
         } else {
             let contentletPlaceholder;
-            if (externalPlaceholderId) {
-                contentletPlaceholder = doc.querySelector(`#${externalPlaceholderId}`);
+            if (placeholderIdToBeReplaced) {
+                contentletPlaceholder = doc.querySelector(`#${placeholderIdToBeReplaced}`);
             } else {
                 contentletPlaceholder = this.getContentletPlaceholder();
                 containerEl.appendChild(contentletPlaceholder);
             }
-                this.dotContainerContentletService
+            
+            this.dotContainerContentletService
                 .getContentletToContainer(this.currentContainer, contentlet)
                 .pipe(take(1))
                 .subscribe((contentletHtml: string) => {
@@ -639,8 +643,8 @@ export class DotEditContentHtmlService {
             'deleted-contenlet': () => {
                 this.removeCurrentContentlet();
             },
-            'add-uploaded-dotAsset': (data: any) => {
-                this.renderAddedContentlet(data.contentlet, data.placeholderId)
+            'add-uploaded-dotAsset': (dotAssetData: DotAssetPayload) => {
+                this.renderAddedContentlet(dotAssetData.contentlet, dotAssetData.placeholderId)
             }
         };
 

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -198,24 +198,34 @@ export class DotEditContentHtmlService {
     }
 
     /**
-     * Render a contrentlet in the DOM after add it
+     * Render a contentlet in the DOM after add it
      *
      * @param * contentlet
      * @memberof DotEditContentHtmlService
      */
-    renderAddedContentlet(contentlet: DotPageContent): void {
+    renderAddedContentlet(contentlet: DotPageContent, externalPlaceholderId?: string): void {
         const doc = this.getEditPageDocument();
+
+        if (externalPlaceholderId) {
+            const container: HTMLElement = doc.querySelector(`#${externalPlaceholderId}`).closest('[data-dot-object="container"]');
+            this.setContainterToAppendContentlet({ identifier: container.dataset['dotIdentifier'], uuid: container.dataset['dotUuid']});
+        }
+
         const containerEl: HTMLElement = doc.querySelector(
-            // eslint-disable-next-line max-len
             `[data-dot-object="container"][data-dot-identifier="${this.currentContainer.identifier}"][data-dot-uuid="${this.currentContainer.uuid}"]`
         );
 
         if (this.isContentExistInContainer(contentlet, containerEl)) {
             this.showContentAlreadyAddedError();
         } else {
-            const contentletPlaceholder = this.getContentletPlaceholder();
-            containerEl.appendChild(contentletPlaceholder);
-            this.dotContainerContentletService
+            let contentletPlaceholder;
+            if (externalPlaceholderId) {
+                contentletPlaceholder = doc.querySelector(`#${externalPlaceholderId}`);
+            } else {
+                contentletPlaceholder = this.getContentletPlaceholder();
+                containerEl.appendChild(contentletPlaceholder);
+            }
+                this.dotContainerContentletService
                 .getContentletToContainer(this.currentContainer, contentlet)
                 .pipe(take(1))
                 .subscribe((contentletHtml: string) => {
@@ -628,6 +638,9 @@ export class DotEditContentHtmlService {
             },
             'deleted-contenlet': () => {
                 this.removeCurrentContentlet();
+            },
+            'add-uploaded-dotAsset': (data: any) => {
+                this.renderAddedContentlet(data.contentlet, data.placeholderId)
             }
         };
 

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -32,6 +32,7 @@ import { DotPageContainer } from '@models/dot-page-container/dot-page-container.
 import { DotLicenseService } from '@services/dot-license/dot-license.service';
 import { INLINE_TINYMCE_SCRIPTS } from '@dotcms/app/portlets/dot-edit-page/content/services/html/libraries/inline-edit-mode.js';
 import { HttpErrorResponse } from '@angular/common/http';
+import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 export enum DotContentletAction {
     EDIT,
@@ -68,6 +69,7 @@ export class DotEditContentHtmlService {
         private dotEditContentToolbarHtmlService: DotEditContentToolbarHtmlService,
         private dotDOMHtmlUtilService: DotDOMHtmlUtilService,
         private dotDialogService: DotAlertConfirmService,
+        private dotHttpErrorManagerService: DotHttpErrorManagerService,
         private dotMessageService: DotMessageService,
         private dotGlobalMessageService: DotGlobalMessageService,
         private dotWorkflowActionsFireService: DotWorkflowActionsFireService,
@@ -645,6 +647,12 @@ export class DotEditContentHtmlService {
             },
             'add-uploaded-dotAsset': (dotAssetData: DotAssetPayload) => {
                 this.renderAddedContentlet(dotAssetData.contentlet, dotAssetData.placeholderId)
+            },
+            'handle-http-error': (err: HttpErrorResponse) => {
+                this.dotHttpErrorManagerService
+                        .handle(err)
+                        .pipe(take(1))
+                        .subscribe(() => {});
             }
         };
 

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/dot-contentlets-events.model.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/dot-contentlets-events.model.ts
@@ -6,9 +6,15 @@ export interface DotContentletEvent<T> {
     data: T;
 }
 
+export interface DotContentletEventDragAndDropDotAsset extends DotContentletEvent<DotAssetPayload> {}
 export interface DotContentletEventRelocate extends DotContentletEvent<DotRelocatePayload> {}
 export interface DotContentletEventSelect extends DotContentletEvent<DotPageContent> {}
 export interface DotContentletEventSave extends DotContentletEvent<DotPageContent> {}
+
+export interface DotAssetPayload {
+    contentlet: DotPageContent;
+    placeholderId: string;
+}
 
 export interface DotRelocatePayload {
     container: DotPageContainer;

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -144,7 +144,7 @@ export const EDIT_PAGE_JS = `
         }
     });
 
-    // D&D Img - Start
+    // D&D DotAsset - Start
 
     function dotAssetCreate(options) {
         var promises = [];
@@ -228,6 +228,12 @@ export const EDIT_PAGE_JS = `
         }
     }
 
+    function setLoadingIndicator() {
+        var currentContentlet = document.getElementById('contentletPlaceholder');
+        currentContentlet.classList.remove('gu-transit');
+        currentContentlet.innerHTML = '<div class="loader__overlay"><div class="loader"></div></div>';
+    }
+
     function isCursorOnUpperSide(cursor, contentletBoundingRect) {
         return cursor.y - contentletBoundingRect.top  <  (contentletBoundingRect.bottom - contentletBoundingRect.top)/2
     }
@@ -254,7 +260,7 @@ export const EDIT_PAGE_JS = `
         document.getElementById(elemId).remove()
     }
 
-    function checkIfContainerAllowsContent(event) {
+    function checkIfContainerAllowsDotAsset(event) {
 
         var container = event.target.closest('[data-dot-object="container"]');
         
@@ -269,7 +275,7 @@ export const EDIT_PAGE_JS = `
         }
 
         // Container does NOT allow img
-        if (!container.dataset.dotAcceptTypes.toLocaleLowerCase().match(/image/g)) {
+        if (!container.dataset.dotAcceptTypes.toLocaleLowerCase().match(/dotasset/g)) {
             return false;
         }
 
@@ -287,7 +293,7 @@ export const EDIT_PAGE_JS = `
         var container = event.target.closest('[data-dot-object="container"]');
         currentContainer = container;
 
-        if (container && !checkIfContainerAllowsContent(event)) {
+        if (container && !checkIfContainerAllowsDotAsset(event)) {
             container.classList.add('no');
         }
 
@@ -343,29 +349,26 @@ export const EDIT_PAGE_JS = `
         var container = event.target.closest('[data-dot-object="container"]');
 
         if (container && !container.classList.contains('no')) {
-            console.log('** INSERT', event.dataTransfer.files[0]);
+
+            setLoadingIndicator();
             uploadFile(event.dataTransfer.files[0]).then((dotCMSTempFile) => {
                 dotAssetCreate({
                     files: [dotCMSTempFile],
                     url: '/api/v1/workflow/actions/default/fire/PUBLISH',
                     folder: ''
                 }).then((response) => {
-                    console.log('*** termino', response)
-                    // this.hideOverlay();
-                    // debugger;
-                    // this.uploadComplete.emit(response);
+                    window.contentletEvents.next({
+                        name: 'add-uploaded-dotAsset',
+                        data: {
+                            contentlet: response[0],
+                            placeholderId: 'contentletPlaceholder'
+                        }
+                    });
                 })
             })
-            
 
-        } else {
-            console.log('** NO INSERT')
         }
 
-        if (isContentletPlaceholderInDOM()) {
-                removeElementById('contentletPlaceholder');
-        }
-        
         if (container) {
             container.classList.remove('no');
         }
@@ -373,6 +376,7 @@ export const EDIT_PAGE_JS = `
     }, false)
 
     // D&D Img - End
+
 })();
 
 `;

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -143,6 +143,140 @@ export const EDIT_PAGE_JS = `
             return this.down && drake.dragging;
         }
     });
+
+    // D&D Img - Start
+
+    function isCursorOnUpperSide(cursor, contentletBoundingRect) {
+        return cursor.y - contentletBoundingRect.top  <  (contentletBoundingRect.bottom - contentletBoundingRect.top)/2
+    }
+
+    function isContentletPlaceholderInDOM() {
+        return document.getElementById('contentletPlaceholder');
+    }
+
+    function isContainerAndContentletValid(container, contentlet) {
+        return !container.classList.contains('no') && !contentlet.classList.contains('gu-transit');
+    }
+
+    function insertBeforeElement(newElem, element) {
+        element.parentNode.insertBefore(newElem, element);
+    }
+
+    function insertAfterElement(newElem, element) {
+        try{
+            element.parentNode.insertBefore(newElem, element.nextSibling);
+        }catch(error){}
+    }
+
+    function removeElementById(elemId) {
+        document.getElementById(elemId).remove()
+    }
+
+    function checkIfContainerAllowsContent(event) {
+
+        var container = event.target.closest('[data-dot-object="container"]');
+        
+        // Different than 1 file
+        if (event.dataTransfer.items.length !== 1 ) {
+            return false;
+        }
+
+        // File uploaded not an img
+        if (!event.dataTransfer.items[0].type.match(/image/g) ) {
+            return false;
+        }
+
+        // Container does NOT allow img
+        if (!container.dataset.dotAcceptTypes.toLocaleLowerCase().match(/image/g)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    var contentletPlaceholder;
+    var currentContainer;
+
+    window.addEventListener("dragenter", (event) => {
+        
+        event.preventDefault(); 
+        event.stopPropagation();
+
+        var container = event.target.closest('[data-dot-object="container"]');
+        currentContainer = container;
+
+        if (container && !checkIfContainerAllowsContent(event)) {
+            container.classList.add('no');
+        }
+
+    }, false);
+
+    window.addEventListener('dragover', (event) => {
+
+        event.preventDefault(); 
+        event.stopPropagation();
+
+        var container = event.target.closest('[data-dot-object="container"]');
+        var contentlet = event.target.closest('[data-dot-object="contentlet"]');
+
+        if (contentlet) {
+
+            if (isContainerAndContentletValid(container, contentlet) && isContentletPlaceholderInDOM()) { 
+                removeElementById('contentletPlaceholder');
+            }
+
+            contentletPlaceholder = document.createElement('div');
+            contentletPlaceholder.id = 'contentletPlaceholder';
+            contentletPlaceholder.setAttribute('data-dot-object', 'contentlet')
+            contentletPlaceholder.classList.add('gu-transit')
+            
+            if (isContainerAndContentletValid(container, contentlet) && isCursorOnUpperSide(event, contentlet.getBoundingClientRect())) {
+                insertBeforeElement(contentletPlaceholder, contentlet);
+            } else if (isContainerAndContentletValid(container, contentlet)) {
+                insertAfterElement(contentletPlaceholder, contentlet);
+            }
+
+            contentletPlaceholder = null;
+
+        }
+
+    }, false)
+
+    window.addEventListener('dragleave', (event) => {
+        event.preventDefault(); 
+        event.stopPropagation();
+
+        var container = event.target.closest('[data-dot-object="container"]');
+
+        if (container && currentContainer !== container) {
+            container.classList.remove('no');
+        }
+
+    }, false)
+
+    window.addEventListener('drop', (event) => {
+        event.preventDefault(); 
+        event.stopPropagation();
+
+        var container = event.target.closest('[data-dot-object="container"]');
+
+        if (container && !container.classList.contains('no')) {
+            console.log('** INSERT')
+        } else {
+            console.log('** NO INSERT')
+        }
+
+        if (isContentletPlaceholderInDOM()) {
+                removeElementById('contentletPlaceholder');
+        }
+        
+        if (container) {
+            container.classList.remove('no');
+        }
+
+    }, false)
+
+    // D&D Img - End
 })();
 
 `;


### PR DESCRIPTION
### Proposed Changes
* Drag and drop images into containers in edit mode

### Checklist
- [ ] We need to inject JavaScript code in the iframe to allow to do this (apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts)
- [ ] We upload the image to the temp resource
- [ ] We create a dotasset with the image
- [ ] We add the dotasset contentlet to the container

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
