### PR TITLE
dotCMS/core#20263 fix - Container displays Add button twice under specific situations

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
@@ -279,7 +279,7 @@ describe('DotEditContentToolbarHtmlService', () => {
         describe('default', () => {
             beforeEach(() => {
                 dummyContainer.innerHTML = `
-                    <div data-dot-object="container">
+                    <div data-dot-object="container" data-dot-inode="854ac983-9a18-4a9a-874b-dd18d8be91f5">
                         <div data-dot-object="contentlet" data-dot-can-edit="false" data-dot-has-page-lang-version="true">
                             <div class="large-column"></div>
                         </div>
@@ -295,6 +295,11 @@ describe('DotEditContentToolbarHtmlService', () => {
                 expect(testDoc.querySelectorAll('.dotedit-contentlet__edit').length).toEqual(1);
                 expect(testDoc.querySelectorAll('.dotedit-contentlet__remove').length).toEqual(1);
                 expect(testDoc.querySelectorAll('.dotedit-contentlet__code').length).toEqual(0);
+            });
+
+            it('should create toolbar with dotInode asociated with the container', () => {
+                const toolbar: HTMLElement = testDoc.querySelector(`[data-dot-object="container"]`);
+                expect(toolbar.dataset['dotInode']).toEqual('854ac983-9a18-4a9a-874b-dd18d8be91f5');
             });
 
             it('should have edit button disabled', () => {

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.ts
@@ -71,7 +71,7 @@ export class DotEditContentToolbarHtmlService {
      */
     updateContainerToolbar(container: HTMLElement): void {
         if (container.parentNode) {
-            const toolbar = container.parentNode.querySelector('.dotedit-container__toolbar');
+            const toolbar = container.parentNode.querySelector(`[data-dot-container-inode="${container.dataset['dotInode']}"]`);
             container.parentNode.removeChild(toolbar);
             this.createContainerToolbar(container);
         }
@@ -191,6 +191,7 @@ export class DotEditContentToolbarHtmlService {
     private createContainerToolbar(container: HTMLElement) {
         const containerToolbar = document.createElement('div');
         containerToolbar.classList.add('dotedit-container__toolbar');
+        containerToolbar.setAttribute('data-dot-container-inode', container.dataset['dotInode']);
 
         if (!container.dataset.dotCanAdd.length) {
             container.classList.add('disabled');


### PR DESCRIPTION
### Proposed Changes
* Customers coming from very old versions of dotCMS might run into specific problems because of their legacy data. It seems like the old way of adding Containers to a Template in the Advanced Template portlet might be interfering with the new Page Edit UI. This is causing the Add Content button -- the purple plus sign -- to show up twice when adding or moving contents around inside a specific Container.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
