### PR TITLE
dotCMS/core#20677 Users without the 'Login As' Role are still able to select Login As and see all Users

### DIFF
--- a/apps/dotcms-ui/src/app/test/login-service.mock.ts
+++ b/apps/dotcms-ui/src/app/test/login-service.mock.ts
@@ -1,4 +1,4 @@
-import { of as observableOf, Observable, Subject, of } from 'rxjs';
+import { of, Observable, Subject } from 'rxjs';
 import { Auth } from '@dotcms/dotcms-js';
 
 export const mockUser = () => {
@@ -94,19 +94,19 @@ export class LoginServiceMock {
     setAuth(): void {}
 
     loginAs(): Observable<any> {
-        return observableOf({});
+        return of({});
     }
 
     logoutAs(): Observable<any> {
-        return observableOf({});
+        return of({});
     }
 
     loginUser(): Observable<any> {
-        return observableOf(mockUserWithRedirect);
+        return of(mockUserWithRedirect);
     }
 
     logOutUser(): Observable<any> {
-        return observableOf({});
+        return of({});
     }
 
     watchUser(func: Function): void {
@@ -122,7 +122,7 @@ export class LoginServiceMock {
     }
 
     getLoginFormInfo(): Observable<any> {
-        return observableOf({
+        return of({
             i18nMessagesMap: {
                 'sign-in': 'Sign in'
             },
@@ -135,11 +135,11 @@ export class LoginServiceMock {
     }
 
     recoverPassword(): Observable<any> {
-        return observableOf({});
+        return of({});
     }
 
     changePassword(): Observable<any> {
-        return observableOf({});
+        return of({});
     }
 
     getCurrentUser() {

--- a/apps/dotcms-ui/src/app/test/login-service.mock.ts
+++ b/apps/dotcms-ui/src/app/test/login-service.mock.ts
@@ -1,4 +1,4 @@
-import { of as observableOf, Observable, Subject } from 'rxjs';
+import { of as observableOf, Observable, Subject, of } from 'rxjs';
 import { Auth } from '@dotcms/dotcms-js';
 
 export const mockUser = () => {
@@ -140,5 +140,16 @@ export class LoginServiceMock {
 
     changePassword(): Observable<any> {
         return observableOf({});
+    }
+
+    getCurrentUser() {
+        return of({
+            email: 'admin@dotcms.com',
+            givenName: 'Admin',
+            loginAs: true,
+            roleId: 'e7d4e34e-5127-45fc-8123-d48b62d510e3',
+            surname: 'User',
+            userId: 'dotcms.org.1'
+        });
     }
 }

--- a/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.html
@@ -41,11 +41,10 @@
                     [textContent]="'my-account' | dm"
                 ></a>
             </li>
-            <li class="user-menu__item">
+            <li class="user-menu__item" *ngIf="!auth.loginAsUser && (this.haveLoginAsPermission$ | async)">
                 <a
                     href="#"
                     (click)="tooggleLoginAs($event)"
-                    *ngIf="!auth.loginAsUser"
                     id="dot-toolbar-user-link-login-as"
                     [textContent]="'login-as' | dm"
                     >login-as</a

--- a/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.html
@@ -41,7 +41,7 @@
                     [textContent]="'my-account' | dm"
                 ></a>
             </li>
-            <li class="user-menu__item" *ngIf="!auth.loginAsUser && (this.haveLoginAsPermission$ | async)">
+            <li data-testId="login-as" class="user-menu__item" *ngIf="!auth.loginAsUser && (this.haveLoginAsPermission$ | async)">
                 <a
                     href="#"
                     (click)="tooggleLoginAs($event)"

--- a/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
@@ -41,6 +41,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { dotEventSocketURLFactory, MockDotUiColorsService } from '@tests/dot-test-bed';
 import { FormatDateService } from '@services/format-date-service';
 import { DotUiColorsService } from '@services/dot-ui-colors/dot-ui-colors.service';
+import { of } from 'rxjs';
 
 describe('DotToolbarUserComponent', () => {
     let comp: DotToolbarUserComponent;
@@ -161,4 +162,21 @@ describe('DotToolbarUserComponent', () => {
         expect(dotNavigationService.goToFirstPortlet).toHaveBeenCalledTimes(1);
         expect(locationService.reload).toHaveBeenCalledTimes(1);
     });
+
+    it('should hide login as link', () => {
+        comp.auth = mockAuth;
+        spyOn(loginService, 'getCurrentUser').and.returnValue(of({
+            email: 'admin@dotcms.com',
+            givenName: 'Admin',
+            loginAs: false,
+            roleId: 'e7d4e34e-5127-45fc-8123-d48b62d510e3',
+            surname: 'User',
+            userId: 'dotcms.org.1'
+        }));
+
+        fixture.detectChanges();
+
+        const loginAsLink = de.query(By.css('[data-testId="login-as"]'));
+        expect(loginAsLink).toBe(null);
+    })
 });

--- a/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
@@ -1,10 +1,12 @@
 import { Component, ViewChild, OnInit, Inject } from '@angular/core';
 import { DotDropdownComponent } from '@components/_common/dot-dropdown-component/dot-dropdown.component';
 import { IframeOverlayService } from '../../../_common/iframe/service/iframe-overlay.service';
-import { LoginService, Auth, LoggerService, LOGOUT_URL } from '@dotcms/dotcms-js';
+import { LoginService, Auth, LoggerService, LOGOUT_URL, CurrentUser } from '@dotcms/dotcms-js';
 import { LOCATION_TOKEN } from '@dotcms/app/providers';
 import { DotNavigationService } from '@components/dot-navigation/services/dot-navigation.service';
 import { DotRouterService } from '@services/dot-router/dot-router.service';
+import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 @Component({
     selector: 'dot-toolbar-user',
@@ -20,6 +22,8 @@ export class DotToolbarUserComponent implements OnInit {
 
     logoutUrl = `${LOGOUT_URL}?r=${new Date().getTime()}`;
 
+    haveLoginAsPermission$: Observable<boolean>;
+
     constructor(
         @Inject(LOCATION_TOKEN) private location: Location,
         private loggerService: LoggerService,
@@ -33,6 +37,10 @@ export class DotToolbarUserComponent implements OnInit {
         this.loginService.watchUser((auth: Auth) => {
             this.auth = auth;
         });
+
+        this.haveLoginAsPermission$ = this.loginService
+            .getCurrentUser()
+            .pipe(map((res: CurrentUser) => res.loginAs));
     }
 
     /**

--- a/libs/dot-rules/src/lib/services/bundle-service.ts
+++ b/libs/dot-rules/src/lib/services/bundle-service.ts
@@ -53,6 +53,13 @@ export class BundleService {
         this._pushRuleUrl = `/DotAjaxDirector/com.dotcms.publisher.ajax.RemotePublishAjaxAction/cmd/publish`;
     }
 
+    /**
+     * Get current logged in user
+     *
+     * @return {*}  {Observable<IUser>}
+     * @memberof BundleService
+     * @deprecated use getCurrentUser in LoginService
+     */
     getLoggedUser(): Observable<IUser> {
         return this.coreWebService
             .request({

--- a/libs/dotcms-js/src/lib/core/core-web.service.ts
+++ b/libs/dotcms-js/src/lib/core/core-web.service.ts
@@ -70,7 +70,7 @@ export class CoreWebService {
      * @memberof CoreWebService
      * @deprecated
      */
-    request<T>(options: DotRequestOptionsArgs): Observable<HttpResponse<any>> {
+    request<T>(options: DotRequestOptionsArgs): Observable<HttpResponse<T | any>> {
         if (!options.method) {
             options.method = 'GET';
         }

--- a/libs/dotcms-js/src/lib/core/login.service.ts
+++ b/libs/dotcms-js/src/lib/core/login.service.ts
@@ -7,6 +7,7 @@ import { Observable, Subject, of } from 'rxjs';
 import { HttpCode } from './util/http-code';
 import { pluck, tap, map } from 'rxjs/operators';
 import { DotcmsEventsService } from './dotcms-events.service';
+import { HttpResponse } from '@angular/common/http';
 
 export interface DotLoginParams {
     login: string;
@@ -45,11 +46,26 @@ export class LoginService {
             logoutAs: 'v1/users/logoutas',
             recoverPassword: 'v1/forgotpassword',
             serverInfo: 'v1/loginform',
-            userAuth: 'v1/authentication'
+            userAuth: 'v1/authentication',
+            current: '/api/v1/users/current/'
         };
 
         // when the session is expired/destroyed
         dotcmsEventsService.subscribeTo('SESSION_DESTROYED').subscribe(() => this.logOutUser());
+    }
+
+    /**
+     * Get current logged in user
+     *
+     * @return {*}  {Observable<CurrentUser>}
+     * @memberof LoginService
+     */
+    getCurrentUser(): Observable<CurrentUser> {
+        return this.coreWebService
+            .request<CurrentUser>({
+                url: this.urls.current
+            })
+            .pipe(map((res: HttpResponse<CurrentUser>) => res)) as unknown as Observable<CurrentUser>
     }
 
     get loginAsUsersList$(): Observable<User[]> {
@@ -301,6 +317,15 @@ export class LoginService {
     private logOutUser(): void {
         window.location.href = `${LOGOUT_URL}?r=${new Date().getTime()}`;
     }
+}
+
+export interface CurrentUser {
+    email: string;
+    givenName: string;
+    loginAs: boolean
+    roleId: string;
+    surname: string;
+    userId: string;
 }
 
 export interface User {


### PR DESCRIPTION
### Proposed Changes
* Show **Login As** only if the user have permissions

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
