### PR TITLE
dotCMS/core#18411 fix drag-and-drop-max-contentlet-limit-broken

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -269,6 +269,11 @@ export const EDIT_PAGE_JS = `
             return false;
         }
 
+        // Container reached max contentlet's limit
+        if (container.querySelectorAll('[data-dot-object="contentlet"]').length === parseInt(container.dataset.maxContentlets, 10)) {
+            return false;
+        }
+
         return true;
     }
 
@@ -329,11 +334,15 @@ export const EDIT_PAGE_JS = `
                 }
             }
 
-        } else if (container && !container.querySelectorAll('[data-dot-object="contentlet"]').length) { // Empty container
-            if (isContainerValid(container) && isContentletPlaceholderInDOM()) { 
+        } else if (
+                container && 
+                !container.querySelectorAll('[data-dot-object="contentlet"]').length && 
+                isContainerValid(container)
+            ) { // Empty container
+
+            if (isContentletPlaceholderInDOM()) { 
                 removeElementById('contentletPlaceholder');
             }
-
             container.appendChild(setPlaceholderContentlet()); 
         }
     }


### PR DESCRIPTION
### Proposed Changes
1. If you create a container (not file) and add "Activity" you can dragover files and add the marker
2. Is not respecting the max contentlet field, there is in data-max-contentlets="2" that we need to check

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
