### PR TITLE
dotCMS/core#18411 fix max contentlet limit on containers - content palette

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -276,7 +276,7 @@ export const EDIT_PAGE_JS = `
     }
 
     function checkIfContainerAllowContentType(container) {
-        if (container.querySelectorAll('[data-dot-object="contentlet"]').length === parseInt(container.dataset.maxContentlets, 10)) {
+        if (container.querySelectorAll('div:not(.gu-transit)[data-dot-object="contentlet"]').length === parseInt(container.dataset.maxContentlets, 10)) {
             return false;
         }
 


### PR DESCRIPTION
### Proposed Changes

* We have problems when you try to drag and drop images, if you set the max contents=2 you are able to drag&drop just one images, if you set that property =3, then you are able to put just two contents here. Now if you try to add the contentlets via backend, you are able to use the 2 or 3 without problems.

### Checklist
- [ x] Tests
