### PR TITLE
dotCMS/core#1738 fix rules-allowing-tags-with-only-blank-spaces

### DIFF
--- a/libs/dot-rules/src/lib/components/dot-autocomplete-tags/dot-autocomplete-tags.component.ts
+++ b/libs/dot-rules/src/lib/components/dot-autocomplete-tags/dot-autocomplete-tags.component.ts
@@ -32,7 +32,7 @@ export class DotAutocompleteTagsComponent implements OnInit {
     }
 
     checkForTag(event: any) {
-        if (event.keyCode === 13 && event.currentTarget.value) {
+        if (event.keyCode === 13 && event.currentTarget.value.trim()) {
             this.value.push(event.currentTarget.value);
             this.onChange.emit(this.value);
             event.currentTarget.value = null;


### PR DESCRIPTION
### Proposed Changes
you can still add empty tags with blank spaces

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
