### PR TITLE
dotCMS/core#19784 fix-bug-for-custom-Locale-path-not-found

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
@@ -27,7 +27,14 @@ export class DotFormatDateService {
     }
 
     async setLang(lang: string) {
-        const localeLang = await import(`date-fns/locale/${lang}/index.js`);
+        const customLangPath = {
+            'ar': 'ar-DZ',
+            'en': 'en-US',
+            'fa': 'fa-IR',
+            'zh': 'zh-CN',
+            
+        };
+        const localeLang = await import(`date-fns/locale/${customLangPath[lang] || lang}/index.js`);
         this.localeOptions = { locale: localeLang.default };
     }
 

--- a/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
@@ -27,14 +27,19 @@ export class DotFormatDateService {
     }
 
     async setLang(lang: string) {
-        const customLangPath = {
-            'ar': 'ar-DZ',
-            'en': 'en-US',
-            'fa': 'fa-IR',
-            'zh': 'zh-CN',
-            
-        };
-        const localeLang = await import(`date-fns/locale/${customLangPath[lang] || lang}/index.js`);
+        const dateFnsLang = lang.replace('_', '-');
+        let localeLang;
+
+        try {
+            localeLang = await import(`date-fns/locale/${dateFnsLang}/index.js`);
+        } catch (error) {
+            try {
+                localeLang = await import(`date-fns/locale/${dateFnsLang.split('-')[0]}/index.js`);
+            } catch (error) {
+                localeLang = await import(`date-fns/locale/en-US/index.js`);
+            }
+        }
+        
         this.localeOptions = { locale: localeLang.default };
     }
 

--- a/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
@@ -26,15 +26,18 @@ export class DotFormatDateService {
         this._localeOptions = locale;
     }
 
-    async setLang(lang: string) {
-        const dateFnsLang = lang.replace('_', '-');
+    async setLang(languageId: string) {
+        let [langCode, countryCode] = languageId.replace('_', '-').split('-');
         let localeLang;
 
+        langCode = langCode?.toLowerCase() || 'en'
+        countryCode = countryCode?.toLocaleUpperCase() || 'US';
+
         try {
-            localeLang = await import(`date-fns/locale/${dateFnsLang}/index.js`);
+            localeLang = await import(`date-fns/locale/${langCode}-${countryCode}/index.js`);
         } catch (error) {
             try {
-                localeLang = await import(`date-fns/locale/${dateFnsLang.split('-')[0]}/index.js`);
+                localeLang = await import(`date-fns/locale/${langCode}/index.js`);
             } catch (error) {
                 localeLang = await import(`date-fns/locale/en-US/index.js`);
             }

--- a/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.spec.ts
@@ -184,7 +184,7 @@ describe('DotLoginComponent', () => {
             signInButton.triggerEventHandler('click', {});
             expect(loginService.loginUser).toHaveBeenCalledWith(credentials);
             expect(dotRouterService.goToMain).toHaveBeenCalledWith('redirect/to');
-            expect(dotFormatDateService.setLang).toHaveBeenCalledWith('en');
+            expect(dotFormatDateService.setLang).toHaveBeenCalledWith('en_US');
         });
 
         it('should disable fields while waiting login response', () => {

--- a/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.ts
@@ -81,7 +81,7 @@ export class DotLoginComponent implements OnInit, OnDestroy {
                     this.setMessage('');
                     this.dotLoadingIndicatorService.hide();
                     this.dotRouterService.goToMain(user['editModeUrl']);
-                    this.dotFormatDateService.setLang(user.languageId.split('_')[0]);
+                    this.dotFormatDateService.setLang(user.languageId);
                 },
                 (res: any) => {
                     if (this.isBadRequestOrUnathorized(res.status)) {


### PR DESCRIPTION
### Proposed Changes
this fix solves a path not found for a Locale for `Date-fns`, based on the chosen app language

![image](https://user-images.githubusercontent.com/37185433/133337557-29d6046d-2a5d-4c8a-abb1-f2b328855af7.png)


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
