### PR TITLE
dotCMS/core#21010 Make content palette enterprise only 

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-properties/dot-properties.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-properties/dot-properties.service.spec.ts
@@ -5,11 +5,13 @@ import { CoreWebService } from '@dotcms/dotcms-js';
 import { CoreWebServiceMock } from '@tests/core-web.service.mock';
 
 const fakeResponse = {
-    key1: 'data',
-    'list:key1': ['1', '2']
+    entity: {
+        key1: 'data',
+        list: ['1', '2']
+    }
 };
 
-fdescribe('DotPropertiesService', () => {
+describe('DotPropertiesService', () => {
     let service: DotPropertiesService;
     let httpMock: HttpTestingController;
 
@@ -30,7 +32,7 @@ fdescribe('DotPropertiesService', () => {
         expect(service).toBeTruthy();
 
         service.getKey(key).subscribe((response) => {
-            expect(response).toEqual(fakeResponse.key1);
+            expect(response).toEqual(fakeResponse.entity.key1);
         });
         const req = httpMock.expectOne(`/api/v1/configuration/config?keys=${key}`);
         expect(req.request.method).toBe('GET');
@@ -38,11 +40,11 @@ fdescribe('DotPropertiesService', () => {
     });
 
     it('should get ky as a list', () => {
-        const key = 'key1';
+        const key = 'list';
         expect(service).toBeTruthy();
 
         service.getKeyAsList(key).subscribe((response) => {
-            expect(response).toEqual(fakeResponse['list:key1']);
+            expect(response).toEqual(fakeResponse.entity.list);
         });
         const req = httpMock.expectOne(`/api/v1/configuration/config?keys=list:${key}`);
         expect(req.request.method).toBe('GET');

--- a/apps/dotcms-ui/src/app/api/services/dot-properties/dot-properties.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-properties/dot-properties.service.ts
@@ -22,11 +22,7 @@ export class DotPropertiesService {
             .requestView({
                 url: `/api/v1/configuration/config?keys=${key}`
             })
-            .pipe(
-                take(1),
-                pluck('bodyJsonObject'),
-                map((response) => response[key])
-            );
+            .pipe(take(1), pluck('entity', key));
     }
 
     /**
@@ -43,10 +39,6 @@ export class DotPropertiesService {
             .requestView<{ [key: string]: any }>({
                 url: `/api/v1/configuration/config?keys=${finalKey}`
             })
-            .pipe(
-                take(1),
-                pluck('bodyJsonObject'),
-                map((response) => response[finalKey])
-            );
+            .pipe(take(1), pluck('entity', key));
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
@@ -62,8 +62,8 @@
     </ng-container>
 </div>
 <div class="dot-edit-content__palette"
-     *ngIf='isEnterpriseLicense'
-     [class.editMode]='isEditMode'
+     *ngIf="isEnterpriseLicense"
+     [class.editMode]="isEditMode"
      [class.collapsed]="paletteCollapsed">
     <dot-content-palette
         [items]='contentPalletItems'>

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
@@ -61,7 +61,10 @@
         </div>
     </ng-container>
 </div>
-<div class="dot-edit-content__palette" [class.editMode]='isEditMode'  [class.collapsed]="paletteCollapsed">
+<div class="dot-edit-content__palette"
+     *ngIf='isEnterpriseLicense'
+     [class.editMode]='isEditMode'
+     [class.collapsed]="paletteCollapsed">
     <dot-content-palette
         [items]='contentPalletItems'>
     </dot-content-palette>

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -522,7 +522,6 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
                 }
             );
         });
-        debugger;
         blackList.forEach((content) => allowedContent.delete(content.toLocaleLowerCase()));
 
         return contentTypeList.filter(

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -143,9 +143,12 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.dotLicenseService.isEnterprise().subscribe((isEnterprise) => {
-            this.isEnterpriseLicense = isEnterprise;
-        });
+        this.dotLicenseService
+            .isEnterprise()
+            .pipe(take(1))
+            .subscribe((isEnterprise) => {
+                this.isEnterpriseLicense = isEnterprise;
+            });
         this.dotLoadingIndicatorService.show();
         this.setInitalData();
         this.subscribeSwitchSite();

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -511,7 +511,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
 
     private getAllowedContentTypes(
         contentTypeList: DotCMSContentType[],
-        blackList: string[],
+        blackList: string[] = [],
         pageState: DotPageRenderState
     ): DotCMSContentType[] {
         let allowedContent = new Set();
@@ -522,6 +522,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
                 }
             );
         });
+        debugger;
         blackList.forEach((content) => allowedContent.delete(content.toLocaleLowerCase()));
 
         return contentTypeList.filter(

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -38,6 +38,7 @@ import { DotContainerStructure } from '@models/container/dot-container.model';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { DotPropertiesService } from '@services/dot-properties/dot-properties.service';
+import { DotLicenseService } from '@services/dot-license/dot-license.service';
 
 /**
  * Edit content page component, render the html of a page and bind all events to make it ediable.
@@ -66,6 +67,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     contentPalletItems: DotCMSContentType[] = [];
     isEditMode: boolean = false;
     paletteCollapsed = false;
+    isEnterpriseLicense = false;
 
     private readonly customEventsHandler;
     private destroy$: Subject<boolean> = new Subject<boolean>();
@@ -90,7 +92,8 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
         public sanitizer: DomSanitizer,
         public iframeOverlayService: IframeOverlayService,
         private httpErrorManagerService: DotHttpErrorManagerService,
-        private dotConfigurationService: DotPropertiesService
+        private dotConfigurationService: DotPropertiesService,
+        private dotLicenseService: DotLicenseService
     ) {
         if (!this.customEventsHandler) {
             this.customEventsHandler = {
@@ -140,6 +143,9 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
+        this.dotLicenseService.isEnterprise().subscribe((isEnterprise) => {
+            this.isEnterpriseLicense = isEnterprise;
+        });
         this.dotLoadingIndicatorService.show();
         this.setInitalData();
         this.subscribeSwitchSite();
@@ -425,7 +431,9 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
 
     private renderPage(pageState: DotPageRenderState): void {
         if (this.shouldEditMode(pageState)) {
-            this.loadContentPallet(pageState);
+            if (this.isEnterpriseLicense) {
+                this.loadContentPallet(pageState);
+            }
             this.dotEditContentHtmlService.initEditMode(pageState, this.iframe);
             this.isEditMode = true;
         } else {

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -521,7 +521,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     }
 
     private getAllowedContentTypes(
-        contentTypeList: DotCMSContentType[],
+        contentTypeList: DotCMSContentType[] = [],
         blackList: string[] = [],
         pageState: DotPageRenderState
     ): DotCMSContentType[] {

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/models/dot-rendered-page-state.model.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/models/dot-rendered-page-state.model.ts
@@ -35,7 +35,7 @@ export class DotPageRenderState extends DotPageRender {
     get containers(): {
         [key: string]: {
             container: DotContainer;
-            containerStructures?: DotContainerStructure;
+            containerStructures?: DotContainerStructure[];
         };
     } {
         return this.dotRenderedPage.containers;

--- a/apps/dotcms-ui/src/app/shared/models/dot-page/dot-rendered-page.model.ts
+++ b/apps/dotcms-ui/src/app/shared/models/dot-page/dot-rendered-page.model.ts
@@ -1,6 +1,6 @@
 import { DotPage } from './dot-page.model';
 import { DotEditPageViewAs } from '@models/dot-edit-page-view-as/dot-edit-page-view-as.model';
-import { DotContainer } from '@shared/models/container/dot-container.model';
+import { DotContainer, DotContainerStructure } from '@shared/models/container/dot-container.model';
 import { DotLayout, DotTemplate } from '@shared/models/dot-edit-layout-designer';
 
 export module DotPageRender {
@@ -10,6 +10,7 @@ export module DotPageRender {
         containers?: {
             [key: string]: {
                 container: DotContainer;
+                containerStructures?: DotContainerStructure[];
             };
         };
         template?: DotTemplate;


### PR DESCRIPTION
### Proposed Changes
* make palette enterprise only.
* fix filtering error when content types blacklist is not defined. 

### Checklist
- [X] Tests

