### PR TITLE
core/dotCMS#21047 style fix for contentlet move position placeholder

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.css.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.css.ts
@@ -79,10 +79,12 @@ export const getEditPageCss = (timestampId: string): string => {
 
     ${timestampId} [data-dot-object="container"] {
         border: solid 1px #53c2f9 !important;
-        margin-bottom: 40px !important;
+        margin-bottom: 35px !important;
         min-height: 120px !important;
         display: flex !important;
         flex-direction: column !important;
+        padding-bottom: 5px !important;
+        padding-top: 5px !important;
         width: 100% !important;
     }
 
@@ -107,7 +109,7 @@ export const getEditPageCss = (timestampId: string): string => {
     }
 
     ${timestampId} [data-dot-object="contentlet"]:first-child {
-        margin-top: 40px !important;
+        margin-top: 35px !important;
     }
 
     ${timestampId} [data-dot-object="container"].inline-editing [data-dot-object="contentlet"] .dotedit-contentlet__toolbar {
@@ -144,10 +146,13 @@ export const getEditPageCss = (timestampId: string): string => {
         padding: 0px !important;
         margin: 0px !important;
         height: 10px;
-        margin: 0 16px !important;
+        margin: -5px 16px -5px !important;
         z-index: 100 !important;
     }
 
+    ${timestampId} [data-dot-object="contentlet"].gu-transit:not(.gu-mirror):first-child {
+        margin-bottom: 14px !important;
+    }
 
     /* Hide all the elements inside the contentlet while were relocating */
     ${timestampId} [data-dot-object="contentlet"].gu-transit:not(.gu-mirror) * {


### PR DESCRIPTION
### Proposed Changes
* In edit mode, when you drag and drop a contentlets, we show a blue bar that pops in and out to indicate where the content is going to be dropped. This causes the whole list of contentlets to jump around when the bar is shown or hidden. We need to make that bar skinnier - say only 1 or 2px tall and already have the 2 pixel space between the contentlets in the dom so we are only changing the background color. This will prevent the contents from "shaking" or jumping around when we show the DnD drop indicator.

![image](https://user-images.githubusercontent.com/37185433/134565240-dc2806cf-394b-4ead-9f41-8abf3de8d517.png)


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
