### PR TITLE
dotCMS/core#18707 Add messaging to let customers know how to add Apps

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.html
@@ -8,7 +8,13 @@
                 type="text"
                 [placeholder]="('apps.search.placeholder' | dm) || ''"
             />
-            <div>
+            <div class="dot-apps__header-actions">
+                <div class="dot-apps__header-info">
+                    <dot-icon name="help" size="18"></dot-icon>
+                    <a href="https://dotcms.com/docs/latest/apps-integrations" target="_blank"
+                        >{{ 'apps.link.info' | dm }}</a
+                    >
+                </div>
                 <button
                     pButton
                     link

--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
@@ -24,6 +24,24 @@
     }
 }
 
+.dot-apps__header-actions {
+    display: flex;
+}
+
+.dot-apps__header-info {
+    align-self: center;
+    display: flex;
+    margin-right: $spacing-4;
+
+    dot-icon {
+        margin-right: $spacing-1;
+    }
+}
+
+.dot-apps-configuration__action_import_button {
+    margin-right: $spacing-1;
+}
+
 .dot-apps__body {
     display: grid;
     grid-gap: $spacing-4;

--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.spec.ts
@@ -51,6 +51,14 @@ class MockDotAppsCardComponent {
 }
 
 @Component({
+    selector: 'dot-icon',
+    template: ''
+})
+class MockDotIconComponent {
+    @Input() name: string;
+}
+
+@Component({
     selector: 'dot-apps-import-export-dialog',
     template: ''
 })
@@ -93,7 +101,8 @@ describe('DotAppsListComponent', () => {
                 MockDotAppsCardComponent,
                 MockDotNotLicensedComponent,
                 DotMessagePipe,
-                MockDotAppsImportExportDialogComponent
+                MockDotAppsImportExportDialogComponent,
+                MockDotIconComponent
             ],
             imports: [ButtonModule],
             providers: [
@@ -136,6 +145,15 @@ describe('DotAppsListComponent', () => {
 
         it('should contain 2 app configurations', () => {
             expect(fixture.debugElement.queryAll(By.css('dot-apps-card')).length).toBe(2);
+        });
+
+        it('should contain a dot-icon and a link with info on how to create apps', () => {
+            const link = fixture.debugElement.query(By.css('.dot-apps__header-info a'));
+            const icon = fixture.debugElement.query(By.css('.dot-apps__header-info dot-icon'));
+            expect(link.nativeElement.href).toBe('https://dotcms.com/docs/latest/apps-integrations');
+            expect(link.nativeElement.target).toBe('_blank');
+            expect(icon.componentInstance.name).toBe('help');
+            
         });
 
         it('should set messages to Search Input', () => {

--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.module.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.module.ts
@@ -10,6 +10,7 @@ import { DotPipesModule } from '@pipes/dot-pipes.module';
 import { NotLicensedModule } from '@components/not-licensed/not-licensed.module';
 import { ButtonModule } from 'primeng/button';
 import { DotAppsImportExportDialogModule } from '../dot-apps-import-export-dialog/dot-apps-import-export-dialog.module';
+import { DotIconModule } from '@dotcms/ui';
 
 @NgModule({
     imports: [
@@ -19,7 +20,8 @@ import { DotAppsImportExportDialogModule } from '../dot-apps-import-export-dialo
         DotAppsCardModule,
         DotPipesModule,
         DotAppsImportExportDialogModule,
-        NotLicensedModule
+        NotLicensedModule,
+        DotIconModule
     ],
     declarations: [DotAppsListComponent],
     exports: [DotAppsListComponent],


### PR DESCRIPTION
### Proposed Changes
* Right now, when a user opens the App screen on a system with no Apps configured, all they see is basically a blank screen. It's not clear at all what Apps are, or how to use them - or even how to figure out how to use them.

It would be helpful to have some messaging letting users know how to add Apps

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
![image](https://user-images.githubusercontent.com/37185433/134982388-d822d909-a4bc-4a67-8b59-3e95cb0de161.png)

