### PR TITLE
dotCMS/core#19747 fix apps-import-dialog-improvements ux

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.html
@@ -6,6 +6,7 @@
     [actions]="dialogActions"
     [appendToBody]="true"
     (hide)="closeExportDialog()"
+    width="26rem"
 >
     <form [formGroup]="form" [ngSwitch]="action" novalidate>
         <ng-container *ngSwitchCase="'Export'">
@@ -16,13 +17,14 @@
                 formControlName="password"
                 name="export-password"
                 type="password"
-                class="dot-apps-import-export-dialog__password"
+                class="dot-apps-export-dialog__password"
                 [placeholder]="'apps.confirmation.export.password.label' | dm"
             />
         </ng-container>
         <ng-container *ngSwitchCase="'Import'">
+            <input #importFile type="file" dotAutofocus (change)="onFileChange($event.target.files)" />
             <input
-                dotAutofocus
+                class="dot-apps-import-dialog__password"
                 autocomplete="new-password"
                 formControlName="password"
                 name="import-password"
@@ -30,8 +32,6 @@
                 type="password"
                 [placeholder]="'apps.confirmation.import.password.label' | dm"
             />
-            <p></p>
-            <input #importFile type="file" (change)="onFileChange($event.target.files)" />
             <input type="hidden" name="fileHidden" formControlName="importFile" />
             <!-- Validation Field -->
         </ng-container>

--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.scss
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.scss
@@ -1,5 +1,9 @@
 @use "variables" as *;
 
-.dot-apps-import-export-dialog__password {
+.dot-apps-export-dialog__password {
     margin-bottom: $spacing-3;
+}
+
+.dot-apps-import-dialog__password {
+    margin-top: $spacing-3;
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.spec.ts
@@ -112,7 +112,9 @@ describe('DotAppsImportExportDialogComponent', () => {
             });
             await hostFixture.whenStable();
             const dialog = de.query(By.css('dot-dialog'));
-            const inputPassword = de.query(By.css('input'));
+            const inputPassword = de.query(By.css('input.dot-apps-import-dialog__password'));
+            const inputFile = de.query(By.css('input[type="file"]'));
+            expect(inputFile.attributes.dotAutofocus).toBeDefined();
             expect(dialog.componentInstance.header).toBe(
                 messageServiceMock.get('apps.confirmation.import.header')
             );
@@ -224,6 +226,23 @@ describe('DotAppsImportExportDialogComponent', () => {
             await hostFixture.whenStable();
             expect(dotAppsService.exportConfiguration).toHaveBeenCalledWith(expectedConfiguration);
             expect(comp.closeExportDialog).toHaveBeenCalledTimes(1);
+        });
+
+        it(`should send configuration to export all apps and not close dialog on Error`, async () => {
+            hostFixture.detectChanges();
+            spyOn(dotAppsService, 'exportConfiguration').and.returnValue(Promise.resolve('error'));
+            spyOn(comp, 'closeExportDialog').and.callThrough();
+
+            await hostFixture.whenStable();
+            comp.form.setValue({
+                password: 'test'
+            });
+
+            hostFixture.detectChanges();
+            const acceptBtn = de.queryAll(By.css('footer button'))[1];
+            acceptBtn.nativeElement.click();
+            await hostFixture.whenStable();
+            expect(comp.closeExportDialog).not.toHaveBeenCalled();
         });
 
         it(`should send configuration to export all sites from a single app and close dialog`, async () => {

--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
@@ -168,8 +168,8 @@ export class DotAppsImportExportDialogComponent implements OnChanges, OnDestroy 
                         .subscribe((status: string) => {
                             if (status !== '400') {
                                 this.resolved.emit(true);
+                                this.closeExportDialog();
                             }
-                            this.closeExportDialog();
                         });
                 },
                 label: this.dotMessageService.get('dot.common.dialog.accept'),

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-alert-confirm/dot-alert-confirm.scss
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-alert-confirm/dot-alert-confirm.scss
@@ -1,0 +1,3 @@
+:host ::ng-deep .p-dialog-mask.p-component-overlay {
+    z-index: 1001!important;
+}


### PR DESCRIPTION
### Proposed Changes
A) * When you click in the import button the focus in the new modal should be in the browse button and not in the password one, this because you have no selected file to know what is the password
B) * After you get an error in the import process we should show the error message and then come back to the import window, right now we show the error and close the window

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
