### PR TITLE
Issue 21180 make draggable only drag button in toolbar edit mode

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -452,6 +452,15 @@ function initDragAndDrop () {
         window.removeEventListener("mousemove", clearScroll, false );
     }
 
+    function disableDraggableHtmlElements() {
+        var containerAnchorsList = document.querySelectorAll('[data-dot-object="container"] a, [data-dot-object="container"] a img');
+        for (var i = 0; i < containerAnchorsList.length; i++) {
+            containerAnchorsList[i].setAttribute("draggable", "false")
+        };
+    }
+
+    disableDraggableHtmlElements();
+
     // D&D Img - End
 }
 


### PR DESCRIPTION
### Proposed Changes
Right now, you can click anywhere on the contentlet and drag it to another location and you get a JS error and a spinner of death.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
![image](https://user-images.githubusercontent.com/37185433/138184478-51734e8b-fcf7-4d14-9052-717673ee305a.png)

