### PR TITLE
Issue 20915 generate secure passwords in users page

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.spec.ts
@@ -94,6 +94,18 @@ describe('DotGenerateSecurePasswordComponent', () => {
             expect(comp.typeInput).toBe('text');
             expect(revealButton.nativeElement.text).toBe('hide');
         });
+
+        it('should reset on close', () => {
+            const revealButton = fixture.debugElement.query(
+                By.css('.dot-generate-secure-password__reveal-link')
+            );
+            dialog.close();
+            fixture.detectChanges();
+            expect(comp.typeInput).toBe('password');
+            expect(comp.value).toBe('');
+            expect(comp.dialogShow).toBe(false);
+            expect(revealButton.nativeElement.text).toBe('Reveal');
+        });
     });
 
     afterEach(() => {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.ts
@@ -50,6 +50,7 @@ export class DotGenerateSecurePasswordComponent implements OnInit, OnDestroy {
     close(): void {
         this.dialogShow = false;
         this.typeInput = 'password';
+        this.revealBtnLabel = this.dotMessageService.get('generate.secure.password.reveal');
         this.value = '';
     }
 


### PR DESCRIPTION
### Proposed Changes
BUG: if I open the dialog and generate a password for a user then hit reveal and close the dialog. And hit "Save".
All subsequent times I open the dialog the label still shows as "Hide" even when the new generated password is hidden.
Is not necessary that you hit save.

![image](https://user-images.githubusercontent.com/37185433/138776439-b6e11ba4-abd9-4690-aade-f4ee13b9b742.png)

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
