### PR TITLE
dotCMS/core#21162 fix Icons in Card View not matching Content Type Icons

### DIFF
--- a/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.e2e.ts
+++ b/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.e2e.ts
@@ -41,11 +41,20 @@ describe('dot-contentlet-thumbnail', () => {
             // TODO: find a way to avoid the onError with an invalid image.
             xit('should show image', async () => {});
 
-            it('should show dot-contentlet-icon', async () => {
+            it('should show dot-contentlet-icon with FileAsset icon', async () => {
                 element.setProperty('contentlet', { ...contentletMock, hasTitleImage: 'false' });
                 await page.waitForChanges();
                 const icon = await page.find('dot-contentlet-icon');
                 expect(await icon.getAttribute('icon')).toEqual(contentletMock.__icon__);
+                expect(await icon.getAttribute('size')).toEqual('30px');
+                expect(await icon.getAttribute('aria-label')).toEqual('Alt test');
+            });
+
+            it('should show dot-contentlet-icon with custom icon', async () => {
+                element.setProperty('contentlet', { ...contentletMock, hasTitleImage: 'false', baseType:'CONTENT', contentTypeIcon: '360' });
+                await page.waitForChanges();
+                const icon = await page.find('dot-contentlet-icon');
+                expect(await icon.getAttribute('icon')).toEqual('360');
                 expect(await icon.getAttribute('size')).toEqual('30px');
                 expect(await icon.getAttribute('aria-label')).toEqual('Alt test');
             });

--- a/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
+++ b/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
@@ -46,7 +46,7 @@ export class DotContentletThumbnail {
                     </div>
                 ) : (
                     <dot-contentlet-icon
-                        icon={this.contentlet?.__icon__}
+                        icon={this.contentlet?.baseType !== 'FILEASSET' ? this.contentlet?.contentTypeIcon : this.contentlet?.__icon__}
                         size={this.iconSize}
                         aria-label={this.alt}
                     />

--- a/libs/dotcms-webcomponents/src/models/dot-contentlet-item.model.ts
+++ b/libs/dotcms-webcomponents/src/models/dot-contentlet-item.model.ts
@@ -1,4 +1,5 @@
 export interface DotContentletItem {
+    contentTypeIcon?: string;
     language: string;
     typeVariable: string;
     modDate: string;


### PR DESCRIPTION
### Proposed Changes
Icons in Card View --> Content Search should match icons that appear on List View --> Content Search

![image](https://user-images.githubusercontent.com/37185433/138783601-a9ff4f5d-0447-4e67-9fdf-8eccdb7cae24.png)

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
