### PR TITLE
Fix the block editor suggestions no showing

### DIFF
--- a/libs/block-editor/src/lib/extensions/actions-menu.extension.ts
+++ b/libs/block-editor/src/lib/extensions/actions-menu.extension.ts
@@ -161,8 +161,8 @@ export const ActionsMenu = (injector: Injector, resolver: ComponentFactoryResolv
             pluginKey: 'actionsMenu',
             element: null,
             suggestion: {
-                char: '/c',
-                allowSpaces: true,
+                char: '/',
+                allowSpaces: false,
                 startOfLine: true,
                 render: () => {
                     return {


### PR DESCRIPTION
### Proposed Changes
* Change the suggestion char to `/` because the tiptap library breaks use `/c`

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
