### PR TITLE
fix add link form position

### DIFF
--- a/libs/block-editor/src/lib/plugins/bubble-link-form.plugin.ts
+++ b/libs/block-editor/src/lib/plugins/bubble-link-form.plugin.ts
@@ -67,18 +67,19 @@ export class BubbleLinkFormView {
 
         this.editor.on('focus', this.focusHandler);
         this.setComponentEvents();
-        this.createTooltip();
     }
 
     update(view: EditorView, prevState?: EditorState): void {
-        const prePluginState = this.pluginKey.getState(view.state);
-        const currentPluginState = this.pluginKey.getState(prevState);
+        const next = this.pluginKey.getState(view.state);
+        const prev = this.pluginKey.getState(prevState);
 
         // Check that the current plugin state is different to previous plugin state.
-        if (prePluginState.toggle === currentPluginState.toggle) {
+        if (next.toggle === prev.toggle) {
             this.detectLinkFormChanges();
             return;
         }
+
+        this.createTooltip();
         
         this.tippy?.state.isVisible ? this.hide() : this.show();
         this.detectLinkFormChanges();
@@ -91,11 +92,14 @@ export class BubbleLinkFormView {
     };
 
     createTooltip() {
-        if (this.tippy) {
-            return;
+        const { element: editorElement } = this.editor.options
+        const editorIsAttached = !!editorElement.parentElement
+
+        if (this.tippy || !editorIsAttached) {
+            return
         }
 
-        this.tippy = tippy(this.editor.view.dom, {
+        this.tippy = tippy(editorElement, {
             duration: 250,
             getReferenceClientRect: null,
             content: this.element,


### PR DESCRIPTION

### Issue Info
The bubble menu shows over the add link form when there is not enough space.

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="1680" alt="Screen Shot 2021-12-08 at 10 33 00 AM" src="https://user-images.githubusercontent.com/72418962/145232176-9239267b-122a-4605-96e7-84de9378461f.png">  |  <img width="1680" alt="Screen Shot 2021-12-08 at 11 09 34 AM" src="https://user-images.githubusercontent.com/72418962/145232327-5595916c-d7a3-4959-ae24-f47a7b219830.png">

