### PR TITLE
dotCMS/core#21357 Minor Improvements to Pallet

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-es-content/dot-es-content.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-es-content/dot-es-content.service.spec.ts
@@ -37,7 +37,7 @@ describe('DotESContentService', () => {
         const req = httpMock.expectOne('/api/content/_search');
         expect(req.request.method).toBe('POST');
         expect(req.request.body).toBe(
-            '{"query":"  +deleted : false   +working : true   +contentType :  blog   +title : *  ","sort":"modDate ASC","limit":40,"offset":"0"}'
+            '{"query":"  +deleted : false   +working : true   +contentType :  blog   +title : *  ","sort":"modDate DESC","limit":40,"offset":"0"}'
         );
         req.flush({ entity: responseData });
     });

--- a/apps/dotcms-ui/src/app/api/services/dot-es-content/dot-es-content.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-es-content/dot-es-content.service.ts
@@ -26,11 +26,11 @@ export interface queryEsParams {
 @Injectable()
 export class DotESContentService {
     private _paginationPerPage = 40;
-    private _offset: string = '0';
+    private _offset = '0';
     private _url = '/api/content/_search';
     private _defaultQueryParams = { '+languageId': '1', '+deleted': 'false', '+working': 'true' };
-    private _sortField: string = 'modDate';
-    private _sortOrder: ESOrderDirection = ESOrderDirection.ASC;
+    private _sortField = 'modDate';
+    private _sortOrder: ESOrderDirection = ESOrderDirection.DESC;
     private _extraParams: Map<string, string> = new Map(Object.entries(this._defaultQueryParams));
 
     constructor(private coreWebService: CoreWebService) {}

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.html
@@ -11,12 +11,11 @@
         draggable="true"
         data-testId="paletteItem"
         (dragstart)="dragStart(item)"
+        (click)="showContentTypesList(item.variable)"
     >
         <dot-icon size="30" [name]="item.icon"></dot-icon>
         <p>{{ item.name }}</p>
-        <button (click)="showContentTypesList(item.variable)">
-            <dot-icon name="keyboard_arrow_right"></dot-icon>
-        </button>
+        <dot-icon name="keyboard_arrow_right" class="arrow"></dot-icon>
     </div>
 </div>
 

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.scss
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.scss
@@ -42,15 +42,20 @@
             width: 100%;
         }
 
-        button {
-            background-color: transparent;
-            border: none;
-            color: $gray;
-            cursor: pointer;
-            padding: 0;
-            position: absolute;
-            right: 0;
-            top: 0;
+        .arrow {
+        background-color: transparent;
+        border: none;
+        color: $gray;
+        cursor: pointer;
+        padding: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: 32px;
+        height: 32px;
+        display: flex;
+        align-items: flex-start;
+        justify-content: flex-end;
         }
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.scss
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.scss
@@ -43,19 +43,19 @@
         }
 
         .arrow {
-        background-color: transparent;
-        border: none;
-        color: $gray;
-        cursor: pointer;
-        padding: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
-        width: 32px;
-        height: 32px;
-        display: flex;
-        align-items: flex-start;
-        justify-content: flex-end;
+            background-color: transparent;
+            border: none;
+            color: $gray;
+            cursor: pointer;
+            padding: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+            width: 32px;
+            height: 32px;
+            display: flex;
+            align-items: flex-start;
+            justify-content: flex-end;
         }
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.spec.ts
@@ -125,13 +125,13 @@ describe('DotPaletteContentTypeComponent', () => {
 
     it('should emit event to show a specific contentlet', () => {
         componentHost.items = data;
-        spyOn(de.componentInstance.show, 'emit').and.callThrough();
+        spyOn(de.componentInstance.selected, 'emit').and.callThrough();
         fixtureHost.detectChanges();
         const buttons = fixtureHost.debugElement.queryAll(
-            By.css('[data-testId="paletteItem"] button')
+            By.css('[data-testId="paletteItem"]')
         );
         buttons[3].nativeElement.click();
         expect(de.componentInstance.itemsFiltered).toEqual(data);
-        expect(de.componentInstance.show.emit).toHaveBeenCalledWith('Text');
+        expect(de.componentInstance.selected.emit).toHaveBeenCalledWith('Text');
     });
 });

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.ts
@@ -17,10 +17,12 @@ import { DotPaletteInputFilterComponent } from '../dot-palette-input-filter/dot-
     styleUrls: ['./dot-palette-content-type.component.scss']
 })
 export class DotPaletteContentTypeComponent implements OnChanges {
-    @ViewChild('filterInput', { static: true })
-    filterInput: DotPaletteInputFilterComponent;
+    @ViewChild('filterInput', { static: true }) filterInput: DotPaletteInputFilterComponent;
+
     @Input() items: DotCMSContentType[] = [];
-    @Output() show = new EventEmitter<string>();
+
+    @Output() selected = new EventEmitter<string>();
+
     itemsFiltered: DotCMSContentType[];
 
     constructor(private dotContentletEditorService: DotContentletEditorService) {}
@@ -51,7 +53,7 @@ export class DotPaletteContentTypeComponent implements OnChanges {
     showContentTypesList(contentTypeVariable: string): void {
         this.filterInput.searchInput.nativeElement.value = '';
         this.itemsFiltered = [...this.items];
-        this.show.emit(contentTypeVariable);
+        this.selected.emit(contentTypeVariable);
     }
 
     /**
@@ -64,5 +66,14 @@ export class DotPaletteContentTypeComponent implements OnChanges {
         this.itemsFiltered = this.items.filter((item) =>
             item.name.toLowerCase().includes(value.toLowerCase())
         );
+    }
+
+    /**
+     * Focus the filter input
+     *
+     * @memberof DotPaletteContentTypeComponent
+     */
+    focusInputFilter() {
+        this.filterInput.focus();
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.html
@@ -1,7 +1,8 @@
 <dot-palette-input-filter
+    #inputFilter
     [value]="filter"
     [goBackBtn]="true"
-    (goBack)="showContentTypesList()"
+    (goBack)="backHandlder()"
     (filter)="filterContentlets($event)"
 ></dot-palette-input-filter>
 

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.html
@@ -2,7 +2,7 @@
     #inputFilter
     [value]="filter"
     [goBackBtn]="true"
-    (goBack)="backHandlder()"
+    (goBack)="backHandler()"
     (filter)="filterContentlets($event)"
 ></dot-palette-input-filter>
 

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.spec.ts
@@ -108,8 +108,6 @@ class MockESPaginatorService {
 export class DotContentletIconMockComponent {
     @Input() icon: string;
     @Input() size: string;
-
-    constructor() {}
 }
 
 describe('DotPaletteContentletsComponent', () => {
@@ -169,7 +167,7 @@ describe('DotPaletteContentletsComponent', () => {
         const contentletIcon = fixtureHost.debugElement.query(By.css('dot-contentlet-icon'));
 
         expect(paginatorService.url).toBe('v1/contenttype');
-        expect(paginatorService.paginationPerPage).toBe(15);
+        expect(paginatorService.paginationPerPage).toBe(25);
         expect(paginatorService.sortField).toBe('modDate');
         expect(paginatorService.sortOrder).toBe(1);
         expect(paginatorService.setExtraParams).toHaveBeenCalledWith('type', 'Form');
@@ -200,7 +198,7 @@ describe('DotPaletteContentletsComponent', () => {
         );
 
         expect(paginatorESService.get).toHaveBeenCalledWith({
-            itemsPerPage: 15,
+            itemsPerPage: 25,
             lang: '1',
             filter: '',
             offset: '0',
@@ -256,7 +254,7 @@ describe('DotPaletteContentletsComponent', () => {
         const paginatorContainer = fixtureHost.debugElement.query(By.css('p-paginator'));
 
         expect(paginatorContainer).toBeTruthy();
-        expect(paginatorContainer.componentInstance.rows).toBe(15);
+        expect(paginatorContainer.componentInstance.rows).toBe(25);
         expect(paginatorContainer.componentInstance.totalRecords).toBe(20);
         expect(paginatorContainer.componentInstance.showFirstLastIcon).toBe(false);
         expect(paginatorContainer.componentInstance.pageLinkSize).toBe('2');
@@ -267,7 +265,7 @@ describe('DotPaletteContentletsComponent', () => {
         await fixtureHost.whenStable();
 
         expect(paginatorESService.get).toHaveBeenCalledWith({
-            itemsPerPage: 15,
+            itemsPerPage: 25,
             lang: '1',
             filter: '',
             offset: '15',
@@ -322,7 +320,7 @@ describe('DotPaletteContentletsComponent', () => {
                 resultsSize: 2
             })
         );
-        spyOn(de.componentInstance.hide, 'emit').and.callThrough();
+        spyOn(de.componentInstance.back, 'emit').and.callThrough();
         componentHost.languageId = '1';
         componentHost.contentTypeVariable = 'Product';
 
@@ -335,7 +333,7 @@ describe('DotPaletteContentletsComponent', () => {
         expect(filterComp.componentInstance.goBackBtn).toBe(true);
         expect(de.componentInstance.items).toEqual(null);
         expect(de.componentInstance.filter).toEqual('');
-        expect(de.componentInstance.hide.emit).toHaveBeenCalled();
+        expect(de.componentInstance.back.emit).toHaveBeenCalled();
     });
 
     it('should filter Product items on search via DotESContent', async () => {
@@ -359,7 +357,7 @@ describe('DotPaletteContentletsComponent', () => {
         fixtureHost.detectChanges();
 
         expect(paginatorESService.get).toHaveBeenCalledWith({
-            itemsPerPage: 15,
+            itemsPerPage: 25,
             lang: '1',
             filter: 'test',
             offset: '0',

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.ts
@@ -24,13 +24,16 @@ import { DotPaletteInputFilterComponent } from '../dot-palette-input-filter/dot-
 export class DotPaletteContentletsComponent implements OnChanges {
     @Input() contentTypeVariable: string;
     @Input() languageId: string;
-    @Output() hide = new EventEmitter();
+    @Output() back = new EventEmitter();
+
     items: DotCMSContentlet[] | DotCMSContentType[] = [];
     isFormContentType: boolean;
     hideNoResults = true;
     filter: string;
     itemsPerPage = 15;
     totalRecords = 0;
+
+    @ViewChild('inputFilter') inputFilter: DotPaletteInputFilterComponent;
 
     constructor(
         public paginatorESService: DotESContentService,
@@ -101,15 +104,14 @@ export class DotPaletteContentletsComponent implements OnChanges {
     }
 
     /**
-     * Emits notification to show content type's component and clears
-     * component's local variables
+     * Clear component and emit back
      *
      * @memberof DotPaletteContentletsComponent
      */
-    showContentTypesList(): void {
-        this.items = null;
+    backHandlder(): void {
         this.filter = '';
-        this.hide.emit();
+        this.back.emit();
+        this.items = null;
     }
 
     /**
@@ -139,5 +141,14 @@ export class DotPaletteContentletsComponent implements OnChanges {
         }
 
         this.loadData({ first: 0 });
+    }
+
+    /**
+     * Focus the input filter
+     *
+     * @memberof DotPaletteContentletsComponent
+     */
+    focusInputFilter(): void {
+        this.inputFilter.focus();
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.ts
@@ -108,7 +108,7 @@ export class DotPaletteContentletsComponent implements OnChanges {
      *
      * @memberof DotPaletteContentletsComponent
      */
-    backHandlder(): void {
+    backHandler(): void {
         this.filter = '';
         this.back.emit();
         this.items = null;

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.ts
@@ -30,7 +30,7 @@ export class DotPaletteContentletsComponent implements OnChanges {
     isFormContentType: boolean;
     hideNoResults = true;
     filter: string;
-    itemsPerPage = 15;
+    itemsPerPage = 25;
     totalRecords = 0;
 
     @ViewChild('inputFilter') inputFilter: DotPaletteInputFilterComponent;

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.html
@@ -10,11 +10,13 @@
 <input
     #searchInput
     data-testId="searchInput"
-    [(ngModel)]="value" 
+    [(ngModel)]="value"
     [placeholder]="'Search' | dm | uppercase"
     pInputText
     type="text"
+    class="p-inputtext-sm"
 />
+
 <dot-icon
     name="search"
     class="dot-palette-input-filter__search-icon"

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.scss
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.scss
@@ -11,24 +11,17 @@
     width: 100%;
 }
 
+.p-inputtext {
+    flex: 1;
+    padding-right: $spacing-5;
+}
+
 .dot-palette-input-filter__back-btn {
     background-color: transparent;
     border: 0;
     cursor: pointer;
     margin: 0 $spacing-1 0 0;
     padding: 0;
-}
-
-input {
-    border: 1px solid $gray-lighter;
-    background: transparent;
-    color: $gray;
-    flex: 1;
-    font-size: $font-size-x-small;
-    height: 24px;
-    outline: 0px;
-    padding-right: $spacing-5;
-    padding-left: $spacing-1;
 }
 
 .dot-palette-input-filter__search-icon {

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.ts
@@ -41,4 +41,13 @@ export class DotPaletteInputFilterComponent implements OnInit, OnDestroy {
         this.destroy$.next(true);
         this.destroy$.complete();
     }
+
+    /**
+     * Focus on the search input
+     *
+     * @memberof DotPaletteInputFilterComponent
+     */
+    focus() {
+        this.searchInput.nativeElement.focus();
+    }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.module.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.module.ts
@@ -1,12 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { InputTextModule } from 'primeng/inputtext';
+
 import { DotPipesModule } from '@pipes/dot-pipes.module';
 import { DotIconModule } from '@dotcms/ui';
 import { DotPaletteInputFilterComponent } from './dot-palette-input-filter.component';
-import { FormsModule } from '@angular/forms';
 
 @NgModule({
-    imports: [CommonModule, DotPipesModule, DotIconModule, FormsModule],
+    imports: [CommonModule, DotPipesModule, DotIconModule, FormsModule, InputTextModule],
     declarations: [DotPaletteInputFilterComponent],
     exports: [DotPaletteInputFilterComponent]
 })

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.html
@@ -1,10 +1,9 @@
 <dot-palette-content-type
-    [class.switch-view]="!!contentTypeVariable"
     [items]="items"
     (show)="switchView($event)"
 ></dot-palette-content-type>
 <dot-palette-contentlets
-    [class.switch-view]="!!contentTypeVariable"
+    [@inOut]="state"
     [contentTypeVariable]="contentTypeVariable"
     [languageId]="languageId"
     (hide)="switchView()"

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.html
@@ -1,10 +1,15 @@
 <dot-palette-content-type
+    #contentTypes
+    (@inOut.done)="onAnimationDone($event)"
+    (selected)="switchView($event)"
+    [@inOut]="stateContentType"
     [items]="items"
-    (show)="switchView($event)"
 ></dot-palette-content-type>
 <dot-palette-contentlets
-    [@inOut]="state"
+    #contentlets
+    (@inOut.done)="onAnimationDone($event)"
+    (back)="switchView()"
+    [@inOut]="stateContentlet"
     [contentTypeVariable]="contentTypeVariable"
     [languageId]="languageId"
-    (hide)="switchView()"
 ></dot-palette-contentlets>

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.spec.ts
@@ -6,6 +6,7 @@ import { By } from '@angular/platform-browser';
 import { dotcmsContentTypeBasicMock } from '@dotcms/app/test/dot-content-types.mock';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CoreWebService, CoreWebServiceMock } from '@dotcms/dotcms-js';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 @Component({
     selector: 'dot-palette-content-type',
@@ -13,9 +14,9 @@ import { CoreWebService, CoreWebServiceMock } from '@dotcms/dotcms-js';
 })
 export class DotPaletteContentTypeMockComponent {
     @Input() items: any[];
-    @Output() show = new EventEmitter<any>();
+    @Output() selected = new EventEmitter<any>();
 
-    constructor() {}
+    focusInputFilter() {}
 }
 
 @Component({
@@ -25,9 +26,10 @@ export class DotPaletteContentTypeMockComponent {
 export class DotPaletteContentletsMockComponent {
     @Input() contentTypeVariable: string;
     @Input() languageId: string;
-    @Output() hide = new EventEmitter<any>();
+    @Output() back = new EventEmitter<any>();
 
-    constructor() {}
+
+    focusInputFilter() {}
 }
 
 const itemMock = {
@@ -56,7 +58,7 @@ describe('DotPaletteComponent', () => {
                 DotPaletteContentletsMockComponent,
                 DotPaletteContentTypeMockComponent
             ],
-            imports: [HttpClientTestingModule],
+            imports: [HttpClientTestingModule, NoopAnimationsModule],
             providers: [{ provide: CoreWebService, useClass: CoreWebServiceMock }]
         });
 
@@ -72,28 +74,30 @@ describe('DotPaletteComponent', () => {
         expect(contentTypeComp.componentInstance.items).toEqual([itemMock]);
     });
 
-    it('should change view to contentlets and set Content Type Variable on contentlets palette view', () => {
+    it('should change view to contentlets and set Content Type Variable on contentlets palette view', async () => {
         const contentTypeComp = fixture.debugElement.query(By.css('dot-palette-content-type'));
-        contentTypeComp.componentInstance.show.emit('Blog');
+        contentTypeComp.triggerEventHandler('selected', 'Blog');
         fixture.detectChanges();
+        await fixture.whenStable();
         const contentContentletsComp = fixture.debugElement.query(
             By.css('dot-palette-contentlets')
         );
-        expect(contentTypeComp.nativeElement.className).toEqual('switch-view');
-        expect(contentContentletsComp.nativeElement.className).toEqual('switch-view');
+        expect(contentTypeComp.nativeElement.style.transform).toEqual('translateX(-100%)');
+        expect(contentContentletsComp.nativeElement.style.transform).toEqual('translateX(-100%)');
         expect(contentContentletsComp.componentInstance.contentTypeVariable).toEqual('Blog');
     });
 
-    it('should change view to content type and unset Content Type Variable on contentlets palette view', () => {
+    it('should change view to content type and unset Content Type Variable on contentlets palette view', async () => {
         const contentContentletsComp = fixture.debugElement.query(
             By.css('dot-palette-contentlets')
         );
-        contentContentletsComp.componentInstance.hide.emit('');
+        contentContentletsComp.triggerEventHandler('back', '');
         comp.languageId = '2';
         fixture.detectChanges();
+        await fixture.whenStable();
         const contentTypeComp = fixture.debugElement.query(By.css('dot-palette-content-type'));
-        expect(contentTypeComp.nativeElement.className).toEqual('');
+        expect(contentTypeComp.nativeElement.style.transform).toEqual('translateX(0px)');
         expect(contentContentletsComp.componentInstance.languageId).toEqual('2');
-        expect(contentContentletsComp.nativeElement.className).toEqual('');
+        expect(contentContentletsComp.nativeElement.style.transform).toEqual('translateX(100%)');
     });
 });

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.ts
@@ -1,6 +1,8 @@
-import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, Input } from '@angular/core';
+import { animate, state, style, transition, trigger, AnimationEvent } from '@angular/animations';
+import { Component, Input, ViewChild } from '@angular/core';
 import { DotCMSContentType } from '@dotcms/dotcms-models';
+import { DotPaletteContentTypeComponent } from './dot-palette-content-type/dot-palette-content-type.component';
+import { DotPaletteContentletsComponent } from './dot-palette-contentlets/dot-palette-contentlets.component';
 
 @Component({
     selector: 'dot-palette',
@@ -9,19 +11,30 @@ import { DotCMSContentType } from '@dotcms/dotcms-models';
     animations: [
         trigger('inOut', [
             state(
-                'contentlet',
+                'contentlet:in',
                 style({
                     transform: 'translateX(-100%)'
                 })
             ),
             state(
-                'type',
+                'contentlet:out',
                 style({
                     transform: 'translateX(100%)'
                 })
             ),
-            transition('type => contentlet', animate('250ms')),
-            transition('contentlet => type', animate('250ms'))
+            state(
+                'contentType:in',
+                style({
+                    transform: 'translateX(0)'
+                })
+            ),
+            state(
+                'contentType:out',
+                style({
+                    transform: 'translateX(-100%)'
+                })
+            ),
+            transition('* => *', animate('250ms')),
         ])
     ]
 })
@@ -29,7 +42,11 @@ export class DotPaletteComponent {
     @Input() items: DotCMSContentType[] = [];
     @Input() languageId: string;
     contentTypeVariable = '';
-    state: 'type' | 'contentlet' = 'type';
+    stateContentlet = 'contentlet:out';
+    stateContentType = 'contentType:in';
+
+    @ViewChild('contentlets') contentlets: DotPaletteContentletsComponent;
+    @ViewChild('contentTypes') contentTypes: DotPaletteContentTypeComponent;
 
     /**
      * Sets value on contentTypeVariable variable to show/hide components on the UI
@@ -39,6 +56,23 @@ export class DotPaletteComponent {
      */
     switchView(variableName?: string): void {
         this.contentTypeVariable = variableName ? variableName : '';
-        this.state = variableName ? 'contentlet' : 'type';
+        this.stateContentlet = variableName ? 'contentlet:in' : 'contentlet:out';
+        this.stateContentType = variableName ? 'contentType:out' : 'contentType:in';
+    }
+
+    /**
+     * Focus on the contentlet component search field
+     *
+     * @param {AnimationEvent} event
+     * @memberof DotPaletteComponent
+     */
+    onAnimationDone(event: AnimationEvent): void {
+        if (event.toState === 'contentlet:in') {
+            this.contentlets.focusInputFilter();
+        }
+
+        if (event.toState === 'contentType:in') {
+            this.contentTypes.focusInputFilter();
+        }
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.ts
@@ -1,17 +1,35 @@
+import { animate, state, style, transition, trigger } from '@angular/animations';
 import { Component, Input } from '@angular/core';
 import { DotCMSContentType } from '@dotcms/dotcms-models';
 
 @Component({
     selector: 'dot-palette',
     templateUrl: './dot-palette.component.html',
-    styleUrls: ['./dot-palette.component.scss']
+    styleUrls: ['./dot-palette.component.scss'],
+    animations: [
+        trigger('inOut', [
+            state(
+                'contentlet',
+                style({
+                    transform: 'translateX(-100%)'
+                })
+            ),
+            state(
+                'type',
+                style({
+                    transform: 'translateX(100%)'
+                })
+            ),
+            transition('type => contentlet', animate('250ms')),
+            transition('contentlet => type', animate('250ms'))
+        ])
+    ]
 })
 export class DotPaletteComponent {
     @Input() items: DotCMSContentType[] = [];
     @Input() languageId: string;
-    contentTypeVariable: string = '';
-
-    constructor() {}
+    contentTypeVariable = '';
+    state: 'type' | 'contentlet' = 'type';
 
     /**
      * Sets value on contentTypeVariable variable to show/hide components on the UI
@@ -21,5 +39,6 @@ export class DotPaletteComponent {
      */
     switchView(variableName?: string): void {
         this.contentTypeVariable = variableName ? variableName : '';
+        this.state = variableName ? 'contentlet' : 'type';
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
@@ -62,7 +62,7 @@
     </ng-container>
 </div>
 <div class="dot-edit-content__palette"
-     *ngIf="isEnterpriseLicense"
+     *ngIf="isEnterpriseLicense && isEditMode"
      [class.editMode]="isEditMode"
      [class.collapsed]="paletteCollapsed">
     <dot-palette


### PR DESCRIPTION
### Proposed Changes
* Make the whole content type box clickable to go to contentlets
* Increase the arrow hit area
* Focus in the input search after animation of going back and forward
* Make th sort order results in contentlets desc and 25

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
