### PR TITLE
dotCMS/core#21417 fix Host Selector Improvements

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
@@ -193,7 +193,7 @@ describe('SiteSelectorComponent', () => {
         comp.handleFilterChange(filter);
 
         expect(paginatorService.getWithOffset).toHaveBeenCalledWith(0);
-        expect(paginatorService.filter).toEqual(filter);
+        expect(paginatorService.filter).toEqual(`*${filter}`);
     });
 
     it('should pass class name to searchable dropdown', () => {
@@ -220,7 +220,7 @@ describe('SiteSelectorComponent', () => {
 
         searchableDropdownComponent.filterChange.emit('');
 
-        expect(paginatorService.filter).toEqual('');
+        expect(paginatorService.filter).toEqual('*');
     });
 
     it('should emit change event', () => {

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
@@ -148,7 +148,7 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof SiteSelectorComponent
      */
     getSitesList(filter = '', offset = 0): void {
-        this.paginationService.filter = filter;
+        this.paginationService.filter = `*${filter}`;
         this.paginationService
             .getWithOffset(offset)
             .pipe(take(1))


### PR DESCRIPTION
### Proposed Changes
When there are a lot of sites, searching for sites is painful. We need to preprend a * to the front of what is typed in the site selector  to allow for wildcard searching.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
