### PR TITLE
dotCMS/core#21418 fix Need to refresh the site selector value after archive current site

### DIFF
--- a/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/libs/dotcms-js/src/lib/core/site.service.ts
@@ -69,13 +69,15 @@ export class SiteService {
 
         const siteIdentifier = data.identifier;
         if (siteIdentifier === this.selectedSite.identifier) {
-            if (name !== 'ARCHIVE_SITE') {
-                this.loadCurrentSite();
-            } else if (name === 'ARCHIVE_SITE') {
-                this.switchToDefaultSite().pipe(take(1)).subscribe((currentSite: Site) => {
-                    this.switchSite(currentSite);
-                });
-            }
+
+            name === 'ARCHIVE_SITE'
+                ? this.switchToDefaultSite()
+                      .pipe(take(1))
+                      .subscribe((currentSite: Site) => {
+                          this.switchSite(currentSite);
+                      })
+                : this.loadCurrentSite();
+
         }
     }
 

--- a/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/libs/dotcms-js/src/lib/core/site.service.ts
@@ -71,6 +71,10 @@ export class SiteService {
         if (siteIdentifier === this.selectedSite.identifier) {
             if (name !== 'ARCHIVE_SITE') {
                 this.loadCurrentSite();
+            } else if (name === 'ARCHIVE_SITE') {
+                this.switchToDefaultSite().subscribe((currentSite: Site) => {
+                    this.switchSite(currentSite);
+                });
             }
         }
     }

--- a/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/libs/dotcms-js/src/lib/core/site.service.ts
@@ -72,7 +72,7 @@ export class SiteService {
             if (name !== 'ARCHIVE_SITE') {
                 this.loadCurrentSite();
             } else if (name === 'ARCHIVE_SITE') {
-                this.switchToDefaultSite().subscribe((currentSite: Site) => {
+                this.switchToDefaultSite().pipe(take(1)).subscribe((currentSite: Site) => {
                     this.switchSite(currentSite);
                 });
             }


### PR DESCRIPTION
If you have an instance with just two sites, and select someone in the site selector and then archive the selected one, we are just leaving the selected site and you can't change this value. And the selected site is archived.

We need to update this value and leave the other one selected.


![image](https://user-images.githubusercontent.com/37185433/146844616-68b05aef-7ae1-4d20-8f4f-24a1e7a8e855.png)

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
