### PR TITLE
dotCMS/core#21459 fix push and publish remove date format error

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.spec.ts
@@ -19,7 +19,7 @@ const mockResponse = {
 const mockFormValue: DotPushPublishData = {
     pushActionSelected: 'publish',
     publishDate: 'Wed Jul 08 2020 10:10:50',
-    expireDate: 'Wed Jul 15 2020 22:10:50',
+    expireDate: undefined,
     environment: ['env1'],
     filterKey: 'hol',
     timezoneId: 'Costa Rica'
@@ -91,6 +91,9 @@ describe('PushPublishService', () => {
             });
 
         const req = httpMock.expectOne(() => true);
+        const currentDateStr = new Date().toISOString().split('T')[0];
+        const currentTimeStr = `${new Date().getHours()}-${new Date().getMinutes()}`
+
         expect(
             req.request.url.indexOf(
                 '/DotAjaxDirector/com.dotcms.publisher.ajax.RemotePublishAjaxAction/cmd/publish'
@@ -98,13 +101,16 @@ describe('PushPublishService', () => {
         ).toBeGreaterThan(-1);
         expect(req.request.method).toBe('POST');
         expect(req.request.body).toBe(
-            `assetIdentifier=${assetIdentifierEncoded}&remotePublishDate=2020-07-08&remotePublishTime=10-10&remotePublishExpireDate=2020-07-15&remotePublishExpireTime=22-10&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1&bundleName=&bundleSelect=&filterKey=hol`
+            `assetIdentifier=${assetIdentifierEncoded}&remotePublishDate=2020-07-08&remotePublishTime=10-10&remotePublishExpireDate=${currentDateStr}&remotePublishExpireTime=${currentTimeStr}&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1&bundleName=&bundleSelect=&filterKey=hol`
         );
         req.flush(mockResponse);
     });
 
-    it('should do a post request and push publish an asset with no filter', () => {
-        const formValue: DotPushPublishData = { ...mockFormValue, filterKey: null };
+    it('should do a post request and push publish Remove an asset', () => {
+        const formValue: DotPushPublishData = { ...mockFormValue, publishDate: undefined };
+        const currentDateStr = new Date().toISOString().split('T')[0];
+        const currentTimeStr = `${new Date().getHours()}-${new Date().getMinutes()}`
+
         pushPublishService
             .pushPublishContent('1234567890', formValue, false)
             .subscribe((items: any) => {
@@ -113,12 +119,33 @@ describe('PushPublishService', () => {
 
         const req = httpMock.expectOne(() => true);
         expect(req.request.body).toBe(
-            'assetIdentifier=1234567890&remotePublishDate=2020-07-08&remotePublishTime=10-10&remotePublishExpireDate=2020-07-15&remotePublishExpireTime=22-10&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1&bundleName=&bundleSelect='
+            `assetIdentifier=1234567890&remotePublishDate=${currentDateStr}&remotePublishTime=${currentTimeStr}&remotePublishExpireDate=${currentDateStr}&remotePublishExpireTime=${currentTimeStr}&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1&bundleName=&bundleSelect=&filterKey=hol`
+        );
+        req.flush(mockResponse);
+    });
+
+    it('should do a post request and push publish an asset with no filter', () => {
+        const formValue: DotPushPublishData = { ...mockFormValue, filterKey: null };
+        const currentDateStr = new Date().toISOString().split('T')[0];
+        const currentTimeStr = `${new Date().getHours()}-${new Date().getMinutes()}`
+
+        pushPublishService
+            .pushPublishContent('1234567890', formValue, false)
+            .subscribe((items: any) => {
+                expect(items).toEqual(mockResponse);
+            });
+
+        const req = httpMock.expectOne(() => true);
+        expect(req.request.body).toBe(
+            `assetIdentifier=1234567890&remotePublishDate=2020-07-08&remotePublishTime=10-10&remotePublishExpireDate=${currentDateStr}&remotePublishExpireTime=${currentTimeStr}&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1&bundleName=&bundleSelect=`
         );
         req.flush(mockResponse);
     });
 
     it('should do a post with the correct URL when is a bundle', () => {
+        const currentDateStr = new Date().toISOString().split('T')[0];
+        const currentTimeStr = `${new Date().getHours()}-${new Date().getMinutes()}`
+
         pushPublishService
             .pushPublishContent('1234567890', mockFormValue, true)
             .subscribe((items: any) => {
@@ -127,7 +154,7 @@ describe('PushPublishService', () => {
 
         const req = httpMock.expectOne(() => true);
         expect(req.request.body).toBe(
-            'assetIdentifier=1234567890&remotePublishDate=2020-07-08&remotePublishTime=10-10&remotePublishExpireDate=2020-07-15&remotePublishExpireTime=22-10&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1&bundleName=&bundleSelect=&filterKey=hol'
+            `assetIdentifier=1234567890&remotePublishDate=2020-07-08&remotePublishTime=10-10&remotePublishExpireDate=${currentDateStr}&remotePublishExpireTime=${currentTimeStr}&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1&bundleName=&bundleSelect=&filterKey=hol`
         );
         req.flush(mockResponse);
     });

--- a/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.ts
@@ -84,8 +84,8 @@ export class PushPublishService {
 
         let result = '';
         result += `assetIdentifier=${encodeURIComponent(assetIdentifier)}`;
-        result += `&remotePublishDate=${this.dotFormatDateService.format(new Date(publishDate), 'yyyy-MM-dd')}`;
-        result += `&remotePublishTime=${this.dotFormatDateService.format(new Date(publishDate), 'HH-mm')}`;
+        result += `&remotePublishDate=${this.dotFormatDateService.format(publishDate ? new Date(publishDate) : new Date(), 'yyyy-MM-dd')}`;
+        result += `&remotePublishTime=${this.dotFormatDateService.format(publishDate ? new Date(publishDate) : new Date(), 'HH-mm')}`;
         result += `&remotePublishExpireDate=${this.dotFormatDateService.format(expireDate ? new Date(expireDate) : new Date(), 'yyyy-MM-dd')}`;
         result += `&remotePublishExpireTime=${this.dotFormatDateService.format(expireDate ? new Date(expireDate) : new Date(), 'HH-mm')}`;
         result += `&timezoneId=${timezoneId}`;


### PR DESCRIPTION
In latest 21.12 (on auth/prod), push remove doesn't work. No error is displayed to the user - the "PUSH" button grays out, but nothing happens, and the push modal doesn't go away. There's an error in the browser console "RangeError: Invalid time value".

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![image](https://user-images.githubusercontent.com/37185433/147978537-b0e5686c-a448-40b9-a9cb-b3ce6727e3bf.png)
