### PR TITLE
dotCMS/core#21195 fix Device Dropdown in Preview Mode Doesn't Sort and Limits 10 Devices

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-devices/dot-devices.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-devices/dot-devices.service.spec.ts
@@ -30,7 +30,8 @@ describe('DotDevicesService', () => {
             `content/respectFrontendRoles/false/render/false/query/+contentType:previewDevice `,
             `+live:true `,
             `+deleted:false `,
-            `+working:true`
+            `+working:true`,
+            `/limit/40/orderby/title`
         ].join('');
 
         dotDevicesService.get().subscribe((devices: DotDevice[]) => {

--- a/apps/dotcms-ui/src/app/api/services/dot-devices/dot-devices.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-devices/dot-devices.service.ts
@@ -26,7 +26,8 @@ export class DotDevicesService {
                     'content',
                     'respectFrontendRoles/false',
                     'render/false',
-                    'query/+contentType:previewDevice +live:true +deleted:false +working:true'
+                    'query/+contentType:previewDevice +live:true +deleted:false +working:true',
+                    'limit/40/orderby/title'
                 ].join('/')
             })
             .pipe(pluck('contentlets'));


### PR DESCRIPTION
Based on Will comment:

"We should show up to 40 devices by default and sort them title asc"

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![image](https://user-images.githubusercontent.com/37185433/148099808-846da10f-0557-4118-a3a2-46c86a2be75d.png)