### PR TITLE
dotCMS/core#21239 Losing changes in edit contentlet when lock/unlock

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
@@ -286,7 +286,8 @@ describe('DotContentletWrapperComponent', () => {
                             name: 'save-page',
                             payload: {
                                 hello: 'world',
-                                contentletInode: 'inode123'
+                                contentletInode: 'inode123',
+                                isMoveAction: true
                             }
                         }
                     };

--- a/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.ts
@@ -155,8 +155,10 @@ export class DotContentletWrapperComponent {
 
     private shouldRefresh(data: any): boolean {
         // is not new content
-        return this.dotRouterService.currentPortlet.url.includes(
-            data?.detail?.payload?.contentletInode
+        return (
+            this.dotRouterService.currentPortlet.url.includes(
+                data?.detail?.payload?.contentletInode
+            ) && data?.detail?.payload?.isMoveAction
         );
     }
 }


### PR DESCRIPTION
When the user edits a contentlet and does lock/unlock the pages refresh and the changes are lost

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
