### PR TITLE
Renaming version to release 22.01

### DIFF
--- a/libs/dotcms-webcomponents/package.json
+++ b/libs/dotcms-webcomponents/package.json
@@ -1,4 +1,4 @@
 {
     "name": "dotcms-webcomponents",
-    "version": "22.01.0-rc.0"
+    "version": "22.1.0-rc.0"
 }

--- a/libs/dotcms-webcomponents/package.json
+++ b/libs/dotcms-webcomponents/package.json
@@ -1,4 +1,4 @@
 {
     "name": "dotcms-webcomponents",
-    "version": "21.12.0-rc.4"
+    "version": "22.01.0-rc.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dotcms-ui",
-    "version": "21.12.0-rc.10",
+    "version": "22.01.0-rc.0",
     "license": "MIT",
     "scripts": {
         "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dotcms-ui",
-    "version": "22.01.0-rc.0",
+    "version": "22.1.0-rc.0",
     "license": "MIT",
     "scripts": {
         "ng": "nx",


### PR DESCRIPTION
This change is required as we didn't generate a release 21.12
