### PR TITLE
dotCMS/core#21414 fix add COMPARE button to Task Detail

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@angular/core';
-import { isValid, format, formatDistanceToNowStrict, parse } from 'date-fns';
+import {
+    differenceInCalendarDays,
+    isValid,
+    format,
+    formatDistanceStrict,
+    parse
+} from 'date-fns';
 import { utcToZonedTime, format as formatTZ } from 'date-fns-tz';
 import { DotcmsConfigService, DotTimeZone } from '@dotcms/dotcms-js';
 interface DotLocaleOptions {
@@ -53,6 +59,19 @@ export class DotFormatDateService {
     }
 
     /**
+     * Get the number of calendar days between the given dates. This means that the 
+     * times are removed from the dates and then the difference in days is calculated.
+     *
+     * @param {Date} startDate
+     * @param {Date} endDate
+     * @returns {number}
+     * @memberof DotFormatDateService
+     */
+    differenceInCalendarDays(startDate: Date, endDate: Date): number {
+        return differenceInCalendarDays(startDate, endDate);
+    }
+
+    /**
      * Checks if a date is valid based on a pattern
      *
      * @param {string} date
@@ -93,11 +112,12 @@ export class DotFormatDateService {
      * Gets relative strict time from on a specific date passed
      *
      * @param {string} time
+     * @param {Date} baseDate
      * @returns {string}
      * @memberof DotFormatDateService
      */
-    getRelative(time: string): string {
-        return formatDistanceToNowStrict(new Date(parseInt(time, 10)), {
+    getRelative(time: string, baseDate = new Date()): string {
+        return formatDistanceStrict(new Date(parseInt(time, 10)), baseDate, {
             ...this.localeOptions,
             addSuffix: true
         });

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
@@ -16,10 +16,10 @@
                         appendTo="body"
                     >
                         <ng-template let-selected pTemplate="selectedItem">
-                            {{ transformVersionItemLabel(selected) }}
+                            {{ selected | dotTransformVersionLabel }}
                         </ng-template>
                         <ng-template let-item pTemplate="item">
-                            {{ transformVersionItemLabel(item) }}
+                            {{ item | dotTransformVersionLabel }}
                         </ng-template>
                     </p-dropdown>
                     <p-selectButton
@@ -119,10 +119,8 @@
                 <td
                     data-testId="table-field-compare"
                     [innerHTML]="
-                        (data.working[field.variable] ? data.working[field.variable] : '')
-                            | dotDiff
-                                : (data.compare[field.variable] ? data.compare[field.variable] : '')
-                                : showDiff
+                        data.working[field.variable]
+                            | dotDiff: data.compare[field.variable]:showDiff
                     "
                 ></td>
             </ng-container>

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
@@ -1,73 +1,130 @@
-<p-table [value]='data.fields' *ngIf='data'  styleClass="p-datatable-gridlines">
-    <ng-template pTemplate='header'>
+<p-table [value]="data.fields" *ngIf="data" styleClass="p-datatable-gridlines">
+    <ng-template pTemplate="header">
         <tr>
-            <th style="width:12%"> </th>
+            <th style="width: 12%"></th>
             <th>
                 <span data-testId="table-tittle" class="dot-content-compare-table__title">
-                    {{data.working?.title}}
+                    {{ data.working?.title }}
                 </span>
             </th>
             <th>
-               <div class="dot-content-compare-table__controls">
-                   <p-dropdown [options]="data.versions" (onChange)='changeVersion.emit($event.value)' appendTo="body" >
-                       <ng-template let-selected pTemplate="selectedItem">
-                           {{selected.modDate}}
-                       </ng-template>
-                       <ng-template let-item pTemplate="item">
-                           {{item.modDate}}
-                       </ng-template>
-                   </p-dropdown>
-                   <p-selectButton
-                       [options]="displayOptions"
-                       [(ngModel)]="showDiff"
-                       class="p-button-tabbed"
-                       (onChange)="changeDiff.emit($event.value)" >
-                   </p-selectButton>
-                   <button data-testId="table-bring-back" pButton class="p-button-sm p-button" [label]="'Bring-Back' | dm" (click)='bringBack.emit(data.compare.inode)'></button>
-               </div>
+                <div class="dot-content-compare-table__controls">
+                    <p-dropdown
+                        [options]="data.versions"
+                        data-testid="versions-dropdown"
+                        (onChange)="changeVersion.emit($event.value)"
+                        appendTo="body"
+                    >
+                        <ng-template let-selected pTemplate="selectedItem">
+                            {{ transformVersionItemLabel(selected) }}
+                        </ng-template>
+                        <ng-template let-item pTemplate="item">
+                            {{ transformVersionItemLabel(item) }}
+                        </ng-template>
+                    </p-dropdown>
+                    <p-selectButton
+                        data-testid="show-diff"
+                        [options]="displayOptions"
+                        [(ngModel)]="showDiff"
+                        class="p-button-compact"
+                        (onChange)="changeDiff.emit($event.value)"
+                    >
+                    </p-selectButton>
+                    <button
+                        data-testId="table-bring-back"
+                        pButton
+                        class="p-button-sm p-button"
+                        [label]="'Bring-Back' | dm"
+                        (click)="bringBack.emit(data.compare.inode)"
+                    ></button>
+                </div>
             </th>
         </tr>
     </ng-template>
 
-    <ng-template pTemplate="body" let-field >
-        <tr [ngSwitch]="field?.fieldType" >
-           <td>{{field.name}}</td>
+    <ng-template pTemplate="body" let-field>
+        <tr [ngSwitch]="field?.fieldType">
+            <td>{{ field.name }}</td>
             <ng-container *ngSwitchCase="'Image'">
-               <td><img data-testId="table-image-working" *ngIf="data.working[field.variable]" [alt]="data.working[field.variable]" [src]="'/dA/'+data.working[field.variable]+'/20q'"></td>
-               <td><img data-testId="table-image-compare" *ngIf="data.compare[field.variable]" [alt]="data.compare[field.variable]" [src]="'/dA/'+data.compare[field.variable]+'/20q'"></td>
+                <td>
+                    <img
+                        data-testId="table-image-working"
+                        *ngIf="data.working[field.variable]"
+                        [alt]="data.working[field.variable]"
+                        [src]="'/dA/' + data.working[field.variable] + '/20q'"
+                    />
+                </td>
+                <td>
+                    <img
+                        data-testId="table-image-compare"
+                        *ngIf="data.compare[field.variable]"
+                        [alt]="data.compare[field.variable]"
+                        [src]="'/dA/' + data.compare[field.variable] + '/20q'"
+                    />
+                </td>
             </ng-container>
-            <ng-container *ngSwitchCase="'File'" >
+            <ng-container *ngSwitchCase="'File'">
                 <td>
-                    <dot-content-compare-preview-field *ngIf="data.working[field.variable]" data-testId="table-file-working"
-                        [fileURL]="'/dA/'+data.working[field.variable]+'/fileAsset/'"
-                        [label]="'/dA/'+data.working[field.variable]+'/fileAsset/'" >
+                    <dot-content-compare-preview-field
+                        *ngIf="data.working[field.variable]"
+                        data-testId="table-file-working"
+                        [fileURL]="'/dA/' + data.working[field.variable] + '/fileAsset/'"
+                        [label]="'/dA/' + data.working[field.variable] + '/fileAsset/'"
+                    >
                     </dot-content-compare-preview-field>
                 </td>
                 <td>
-                    <dot-content-compare-preview-field *ngIf="data.compare[field.variable]" data-testId="table-file-compare"
-                        [fileURL]="'/dA/'+data.compare[field.variable]+'/fileAsset/'"
-                        [label]="'/dA/'+data.working[field.variable]+'/fileAsset/' | dotDiff:'/dA/'+data.compare[field.variable]+'/fileAsset/':showDiff" >
+                    <dot-content-compare-preview-field
+                        *ngIf="data.compare[field.variable]"
+                        data-testId="table-file-compare"
+                        [fileURL]="'/dA/' + data.compare[field.variable] + '/fileAsset/'"
+                        [label]="
+                            '/dA/' + data.working[field.variable] + '/fileAsset/'
+                                | dotDiff
+                                    : '/dA/' + data.compare[field.variable] + '/fileAsset/'
+                                    : showDiff
+                        "
+                    >
                     </dot-content-compare-preview-field>
                 </td>
             </ng-container>
-            <ng-container *ngSwitchCase="'Binary'" >
+            <ng-container *ngSwitchCase="'Binary'">
                 <td>
-                    <dot-content-compare-preview-field *ngIf="data.working[field.variable+'Version']" data-testId="table-binary-working"
-                                                       [fileURL]="data.working[field.variable+'Version']"
-                                                       [label]="data.working[field.variable+'Version']" >
+                    <dot-content-compare-preview-field
+                        *ngIf="data.working[field.variable + 'Version']"
+                        data-testId="table-binary-working"
+                        [fileURL]="data.working[field.variable + 'Version']"
+                        [label]="data.working[field.variable + 'Version']"
+                    >
                     </dot-content-compare-preview-field>
                 </td>
                 <td>
-                    <dot-content-compare-preview-field *ngIf="data.compare[field.variable+'Version']" data-testId="table-binary-compare"
-                                                       [fileURL]="data.compare[field.variable+'Version']"
-                                                       [label]="data.working[field.variable+'Version'] | dotDiff:data.compare[field.variable+'Version']:showDiff" >
+                    <dot-content-compare-preview-field
+                        *ngIf="data.compare[field.variable + 'Version']"
+                        data-testId="table-binary-compare"
+                        [fileURL]="data.compare[field.variable + 'Version']"
+                        [label]="
+                            data.working[field.variable + 'Version']
+                                | dotDiff: data.compare[field.variable + 'Version']:showDiff
+                        "
+                    >
                     </dot-content-compare-preview-field>
                 </td>
             </ng-container>
             <ng-container *ngSwitchDefault>
-                <td data-testId="table-field-working" [innerHTML]="data.working[field.variable]"></td>
-                <td data-testId="table-field-compare" [innerHTML]="(data.working[field.variable] ? data.working[field.variable] : '')  | dotDiff:(data.compare[field.variable] ? data.compare[field.variable] : '') :showDiff" >
-                </td>
+                <td
+                    data-testId="table-field-working"
+                    [innerHTML]="data.working[field.variable]"
+                ></td>
+                <td
+                    data-testId="table-field-compare"
+                    [innerHTML]="
+                        (data.working[field.variable] ? data.working[field.variable] : '')
+                            | dotDiff
+                                : (data.compare[field.variable] ? data.compare[field.variable] : '')
+                                : showDiff
+                    "
+                ></td>
             </ng-container>
         </tr>
     </ng-template>

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
@@ -5,7 +5,7 @@
     align-items: center;
 
     p-dropdown {
-        margin-right: $spacing-4;
+        margin-right: $spacing-3;
     }
 
     button {

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
@@ -15,6 +15,7 @@ import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module
 import { DotcmsConfigService } from '@dotcms/dotcms-js';
 import { DotFormatDateService } from '@services/dot-format-date-service';
 import { of } from 'rxjs';
+import { DotTransformVersionLabelPipe } from '../../pipes/dot-transform-version-label.pipe';
 
 @Component({
     selector: 'dot-test-host-component',
@@ -255,7 +256,8 @@ describe('DotContentCompareTableComponent', () => {
             declarations: [
                 TestHostComponent,
                 DotContentCompareTableComponent,
-                DotContentComparePreviewFieldComponent
+                DotContentComparePreviewFieldComponent,
+                DotTransformVersionLabelPipe
             ],
             imports: [
                 TableModule,

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
@@ -12,6 +12,9 @@ import { FormsModule } from '@angular/forms';
 import { DotContentComparePreviewFieldComponent } from '@components/dot-content-compare/components/fields/dot-content-compare-preview-field/dot-content-compare-preview-field.component';
 import { By } from '@angular/platform-browser';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
+import { DotcmsConfigService } from '@dotcms/dotcms-js';
+import { DotFormatDateService } from '@services/dot-format-date-service';
+import { of } from 'rxjs';
 
 @Component({
     selector: 'dot-test-host-component',
@@ -107,7 +110,7 @@ export const dotContentCompareTableDataMock: DotContentCompareTableData = {
             languageId: 1,
             live: false,
             locked: false,
-            modDate: '1639601771470',
+            modDate: '12/15/2021 - 01:56 PM',
             modUser: 'dotcms.org.1',
             modUserName: 'Admin User',
             owner: 'dotcms.org.1',
@@ -137,7 +140,7 @@ export const dotContentCompareTableDataMock: DotContentCompareTableData = {
             languageId: 1,
             live: false,
             locked: false,
-            modDate: '1639601760776',
+            modDate: '12/12/2021 - 01:56 PM',
             modUser: 'dotcms.org.1',
             modUserName: 'Admin User',
             owner: 'dotcms.org.1',
@@ -262,7 +265,21 @@ describe('DotContentCompareTableComponent', () => {
                 DotMessagePipeModule,
                 FormsModule
             ],
-            providers: [{ provide: DotMessageService, useValue: messageServiceMock }]
+            providers: [
+                { provide: DotMessageService, useValue: messageServiceMock },
+                DotFormatDateService,
+                {
+                    provide: DotcmsConfigService,
+                    useValue: {
+                        getSystemTimeZone: () =>
+                            of({
+                                id: 'America/Costa_Rica',
+                                label: 'Central Standard Time (America/Costa_Rica)',
+                                offset: -21600000
+                            })
+                    }
+                }
+            ]
         });
 
         hostFixture = TestBed.createComponent(TestHostComponent);
@@ -283,11 +300,18 @@ describe('DotContentCompareTableComponent', () => {
             expect(dropdown.options).toEqual(dotContentCompareTableDataMock.versions);
         });
         it('should show selectButton', () => {
-            const select: SelectButton = de.query(By.css('p-selectButton')).componentInstance;
+            const select: SelectButton = de.query(By.css('[data-testId="show-diff"]'))
+                .componentInstance;
             expect(select.options).toEqual([
                 { label: 'Diff', value: true },
                 { label: 'Plain', value: false }
             ]);
+        });
+        it('should show versions selectButton with transformed label', () => {
+            const dropdown = de.query(By.css('[data-testId="versions-dropdown"]')).nativeElement;
+            expect(dropdown.innerText).toEqual(
+                `${dotContentCompareTableDataMock.versions[0].modDate} by ${dotContentCompareTableDataMock.versions[0].modUserName}`
+            );
         });
     });
 

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.ts
@@ -1,8 +1,7 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotContentCompareTableData } from '@components/dot-content-compare/store/dot-content-compare.store';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
-import { DotFormatDateService } from '@services/dot-format-date-service';
 
 @Component({
     selector: 'dot-content-compare-table',
@@ -22,40 +21,5 @@ export class DotContentCompareTableComponent {
         { label: this.dotMessageService.get('plain'), value: false }
     ];
 
-    constructor(
-        private dotMessageService: DotMessageService,
-        private dotFormatDateService: DotFormatDateService
-    ) {}
-
-    /**
-     * Formats the label from the modDate, to show the relative date if modDate less than a week
-     * and author
-     *
-     * @param {DotCMSContentlet} item
-     * @returns {string}
-     * @memberof DotContentCompareTableComponent
-     */
-    transformVersionItemLabel(item: DotCMSContentlet): string {
-        const modDateClean = new Date(item.modDate.replace('- ', ''));
-        const currentServerDate = new Date(
-            this.dotFormatDateService.formatTZ(new Date(), 'MM/dd/yyyy hh:mm:ss aa')
-        );
-
-        const diffDays = this.dotFormatDateService.differenceInCalendarDays(
-            currentServerDate,
-            modDateClean
-        );
-
-        const dateLabel =
-            diffDays > 6
-                ? item.modDate
-                : this.dotFormatDateService.getRelative(
-                      new Date(modDateClean).getTime().toString(),
-                      currentServerDate
-                  );
-
-        const itemLabel = `${dateLabel} ${this.dotMessageService.get('by')} ${item.modUserName}`;
-
-        return itemLabel;
-    }
+    constructor(private dotMessageService: DotMessageService) {}
 }

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.ts
@@ -1,7 +1,8 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotContentCompareTableData } from '@components/dot-content-compare/store/dot-content-compare.store';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
+import { DotFormatDateService } from '@services/dot-format-date-service';
 
 @Component({
     selector: 'dot-content-compare-table',
@@ -21,5 +22,40 @@ export class DotContentCompareTableComponent {
         { label: this.dotMessageService.get('plain'), value: false }
     ];
 
-    constructor(private dotMessageService: DotMessageService) {}
+    constructor(
+        private dotMessageService: DotMessageService,
+        private dotFormatDateService: DotFormatDateService
+    ) {}
+
+    /**
+     * Formats the label from the modDate, to show the relative date if modDate less than a week
+     * and author
+     *
+     * @param {DotCMSContentlet} item
+     * @returns {string}
+     * @memberof DotContentCompareTableComponent
+     */
+    transformVersionItemLabel(item: DotCMSContentlet): string {
+        const modDateClean = new Date(item.modDate.replace('- ', ''));
+        const currentServerDate = new Date(
+            this.dotFormatDateService.formatTZ(new Date(), 'MM/dd/yyyy hh:mm:ss aa')
+        );
+
+        const diffDays = this.dotFormatDateService.differenceInCalendarDays(
+            currentServerDate,
+            modDateClean
+        );
+
+        const dateLabel =
+            diffDays > 6
+                ? item.modDate
+                : this.dotFormatDateService.getRelative(
+                      new Date(modDateClean).getTime().toString(),
+                      currentServerDate
+                  );
+
+        const itemLabel = `${dateLabel} ${this.dotMessageService.get('by')} ${item.modUserName}`;
+
+        return itemLabel;
+    }
 }

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.spec.ts
@@ -20,6 +20,8 @@ import { DotRouterService } from '@services/dot-router/dot-router.service';
 import { MockDotRouterService } from '@tests/dot-router-service.mock';
 import { DotVersionableService } from '@services/dot-verionable/dot-versionable.service';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
+import { DotcmsConfigService } from '@dotcms/dotcms-js';
+import { DotFormatDateService } from '@services/dot-format-date-service';
 
 const DotContentCompareEventMOCK = {
     inode: '1',
@@ -86,6 +88,18 @@ describe('DotContentCompareComponent', () => {
                                 }
                             })
                         )
+                    }
+                },
+                DotFormatDateService,
+                {
+                    provide: DotcmsConfigService,
+                    useValue: {
+                        getSystemTimeZone: () =>
+                            of({
+                                id: 'America/Costa_Rica',
+                                label: 'Central Standard Time (America/Costa_Rica)',
+                                offset: -21600000
+                            })
                     }
                 }
             ]

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.module.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.module.ts
@@ -14,13 +14,15 @@ import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module
 import { DotContentComparePreviewFieldComponent } from '@components/dot-content-compare/components/fields/dot-content-compare-preview-field/dot-content-compare-preview-field.component';
 import { ButtonModule } from 'primeng/button';
 import { DotVersionableService } from '@services/dot-verionable/dot-versionable.service';
+import { DotTransformVersionLabelPipe } from './pipes/dot-transform-version-label.pipe';
 
 @NgModule({
     declarations: [
         DotContentCompareComponent,
         DotContentCompareTableComponent,
         DotContentCompareDialogComponent,
-        DotContentComparePreviewFieldComponent
+        DotContentComparePreviewFieldComponent,
+        DotTransformVersionLabelPipe
     ],
     exports: [DotContentCompareDialogComponent],
     imports: [

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/pipes/dot-transform-version-label.pipe.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/pipes/dot-transform-version-label.pipe.spec.ts
@@ -1,0 +1,63 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { CoreWebService, CoreWebServiceMock, DotcmsConfigService } from '@dotcms/dotcms-js';
+import { DotFormatDateService } from '@services/dot-format-date-service';
+import { DotMessageService } from '@services/dot-message/dot-messages.service';
+import { of } from 'rxjs';
+import { dotContentCompareTableDataMock } from '../components/dot-content-compare-table/dot-content-compare-table.component.spec';
+import { DotTransformVersionLabelPipe } from './dot-transform-version-label.pipe';
+import { format } from 'date-fns';
+
+describe('DotTransformVersionLabelPipe', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [
+                DotMessageService,
+                DotFormatDateService,
+                {
+                    provide: CoreWebService,
+                    useClass: CoreWebServiceMock
+                },
+                {
+                    provide: DotcmsConfigService,
+                    useValue: {
+                        getSystemTimeZone: () =>
+                            of({
+                                id: 'GMT',
+                                label: 'Greenwich Mean Time',
+                                offset: 0
+                            })
+                    }
+                }
+            ]
+        });
+    });
+
+    it('transform label with modUserName, using date older than 7 days (no relative date transform)', () => {
+        const dotMessageService: DotMessageService = TestBed.inject(DotMessageService);
+        const dotFormatDateService: DotFormatDateService = TestBed.inject(DotFormatDateService);
+
+        const pipe = new DotTransformVersionLabelPipe(dotFormatDateService, dotMessageService);
+        expect(pipe.transform(dotContentCompareTableDataMock.working)).toEqual(
+            '12/15/2021 - 02:56 PM by Admin User'
+        );
+    });
+
+    it('transform label with modUserName, using date within 7 days (relative date transform)', () => {
+        const dotMessageService: DotMessageService = TestBed.inject(DotMessageService);
+        const dotFormatDateService: DotFormatDateService = TestBed.inject(DotFormatDateService);
+        const currentDay = format(new Date(), 'MM/dd/YYY');
+        const relativeExpected = dotFormatDateService.getRelative(
+            new Date(currentDay).getTime().toString()
+        );
+
+        const pipe = new DotTransformVersionLabelPipe(dotFormatDateService, dotMessageService);
+        expect(
+            pipe.transform({
+                ...dotContentCompareTableDataMock.working,
+                modDate: `${currentDay} - 00:00`
+            })
+        ).toEqual(`${relativeExpected} by Admin User`);
+    });
+});

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/pipes/dot-transform-version-label.pipe.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/pipes/dot-transform-version-label.pipe.ts
@@ -1,0 +1,41 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DotCMSContentlet } from '@dotcms/dotcms-models';
+import { DotFormatDateService } from '@services/dot-format-date-service';
+import { DotMessageService } from '@services/dot-message/dot-messages.service';
+
+@Pipe({
+    name: 'dotTransformVersionLabel'
+})
+export class DotTransformVersionLabelPipe implements PipeTransform {
+    constructor(
+        private dotFormatDateService: DotFormatDateService,
+        private dotMessageService: DotMessageService
+    ) {}
+
+    transform(item: DotCMSContentlet): string {
+        const modDateClean = new Date(item.modDate.replace('- ', ''));
+        const currentServerDate = new Date(
+            this.dotFormatDateService.formatTZ(new Date(), 'MM/dd/yyyy hh:mm:ss aa')
+        );
+        const relativeDateStr = this.dotFormatDateService.getRelative(
+            new Date(modDateClean).getTime().toString(),
+            currentServerDate
+        );
+
+        const diffDays = this.dotFormatDateService.differenceInCalendarDays(
+            currentServerDate,
+            modDateClean
+        );
+
+        return this.getDateLabel(diffDays, item, relativeDateStr);
+    }
+
+    private getDateLabel(
+        diffDays: number,
+        item: DotCMSContentlet,
+        relativeDateStr: string
+    ): string {
+        const dateLabel = diffDays > 6 ? item.modDate : relativeDateStr;
+        return `${dateLabel} ${this.dotMessageService.get('by')} ${item.modUserName}`;
+    }
+}

--- a/apps/dotcms-ui/src/app/view/pipes/dot-diff/dot-diff.pipe.ts
+++ b/apps/dotcms-ui/src/app/view/pipes/dot-diff/dot-diff.pipe.ts
@@ -6,6 +6,7 @@ import HtmlDiff from 'htmldiff-js';
 })
 export class DotDiffPipe implements PipeTransform {
     transform(oldValue: string, newValue: string, showDiff = true): string {
-        return showDiff ? HtmlDiff.execute(oldValue, newValue) : newValue;
+        newValue = newValue || '';
+        return showDiff ? HtmlDiff.execute(oldValue ? oldValue : '', newValue) : newValue;
     }
 }

--- a/libs/dot-primeng-theme-styles/src/scss/dotcms-theme/components/_selectbutton.scss
+++ b/libs/dot-primeng-theme-styles/src/scss/dotcms-theme/components/_selectbutton.scss
@@ -57,3 +57,19 @@
         }
     }
 }
+
+.p-button-compact {
+    .p-button {
+        padding-left: $spacing-3;
+        padding-right: $spacing-3;
+
+        &.p-highlight {
+            &:focus {
+                background-color: $brand-primary;
+                color: $white;
+            }
+            background-color: $brand-primary;
+            color: $white;
+        }
+    }
+}


### PR DESCRIPTION
### Proposed Changes
We need to add the "Compare contentlet" functionality we added in History in Task Detail as well.

- label of the button should be Compare to previous versions
- in the compare dialog, the dropdown that contains version dates must show relative dates if changes were made before a week, otherwise show the standard datetime. Also make it 20px wider and add the author who did the change
- in the compare dialog change the DIFF/PLAIN switch button to img attached

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
