### PR TITLE
dotCMS/core#21122 Replace What's changed with the htmldiff js library

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-edit-page/dot-edit-page.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-edit-page/dot-edit-page.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { CoreWebService } from '@dotcms/dotcms-js';
 import { DotPageContainer } from '@models/dot-page-container/dot-page-container.model';
 import { Observable } from 'rxjs';
+import { DotWhatChanged } from '@models/dot-what-changed/dot-what-changed.model';
 
 @Injectable()
 export class DotEditPageService {
@@ -14,7 +15,7 @@ export class DotEditPageService {
      * @param string pageId
      * @param DotPageContainer[] content
      * @returns Observable<string>
-     * @memberof DotContainerContentletService
+     * @memberof DotEditPageService
      */
     save(pageId: string, content: DotPageContainer[]): Observable<string> {
         return this.coreWebService
@@ -22,6 +23,22 @@ export class DotEditPageService {
                 method: 'POST',
                 body: content,
                 url: `v1/page/${pageId}/content`
+            })
+            .pipe(pluck('entity'));
+    }
+
+    /**
+     * Get the live and working version markup of specific page.
+     *
+     * @param string pageId
+     * @param string language
+     * @returns Observable<DotWhatChanged>
+     * @memberof DotEditPageService
+     */
+    whatChange(pageId: string, languageId: string): Observable<DotWhatChanged> {
+        return this.coreWebService
+            .requestView({
+                url: `v1/page/${pageId}/render/versions?langId=${languageId}`
             })
             .pipe(pluck('entity'));
     }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -8,14 +8,8 @@ import {
     OnDestroy
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
-
 import { DotLicenseService } from '@services/dot-license/dot-license.service';
 import { DotPageRenderState } from '@portlets/dot-edit-page/shared/models';
-import { DotMessageDisplayService } from '@components/dot-message-display/services';
-import { DotEventsService } from '@services/dot-events/dot-events.service';
-import { DotEvent } from '@shared/models/dot-event/dot-event';
-import { DotMessageSeverity, DotMessageType } from '@components/dot-message-display/model';
 import { DotPageMode } from '@models/dot-page/dot-page-mode.enum';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 
@@ -39,11 +33,7 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
-    constructor(
-        private dotLicenseService: DotLicenseService,
-        private dotEventsService: DotEventsService,
-        private dotMessageDisplayService: DotMessageDisplayService
-    ) {}
+    constructor(private dotLicenseService: DotLicenseService) {}
 
     ngOnInit() {
         this.isEnterpriseLicense$ = this.dotLicenseService.isEnterprise();

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.html
@@ -1,1 +1,10 @@
-<dot-iframe [src]="url"></dot-iframe>
+<dot-iframe *ngIf="whatsChanged.diff else noChanges" #dotIframe></dot-iframe>
+<ng-template   #noChanges>
+    <span class='whats-changed__empty-state'>
+        {{'nothing-changed' | dm}}
+    </span>
+</ng-template>
+
+
+
+

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.html
@@ -1,5 +1,5 @@
 <dot-iframe *ngIf="whatsChanged.diff else noChanges" #dotIframe></dot-iframe>
-<ng-template   #noChanges>
+<ng-template #noChanges>
     <span class='whats-changed__empty-state'>
         {{'nothing-changed' | dm}}
     </span>

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.scss
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 :host {
     display: flex;
     flex-direction: column;
@@ -10,5 +12,11 @@
         ::ng-deep iframe {
             flex-grow: 1;
         }
+    }
+
+    .whats-changed__empty-state {
+        text-align: center;
+        margin-top: $spacing-9;
+        font-size: $font-size-xx-large;
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.ts
@@ -1,20 +1,72 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
+import { DotDiffPipe } from '@dotcms/app/view/pipes';
+import { IframeComponent } from '@components/_common/iframe/iframe-component';
+import { DotEditPageService } from '@services/dot-edit-page/dot-edit-page.service';
+import { take } from 'rxjs/operators';
+import { DotWhatChanged } from '@models/dot-what-changed/dot-what-changed.model';
+import { DotDOMHtmlUtilService } from '@portlets/dot-edit-page/content/services/html/dot-dom-html-util.service';
 
 @Component({
     selector: 'dot-whats-changed',
     templateUrl: './dot-whats-changed.component.html',
     styleUrls: ['./dot-whats-changed.component.scss']
 })
-export class DotWhatsChangedComponent implements OnChanges {
+export class DotWhatsChangedComponent implements OnInit, OnChanges {
     @Input()
     languageId: string;
     @Input()
     pageId: string;
-    url: string;
+    styles: HTMLStyleElement;
 
-    constructor() {}
+    @ViewChild('dotIframe', { static: false }) dotIframe: IframeComponent;
+
+    private dotDiffPipe = new DotDiffPipe();
+    whatsChanged: DotWhatChanged = { diff: true, renderLive: '', renderWorking: '' };
+
+    constructor(
+        private dotEditPageService: DotEditPageService,
+        private dotDOMHtmlUtilService: DotDOMHtmlUtilService
+    ) {}
+
+    ngOnInit(): void {
+        this.styles = this.dotDOMHtmlUtilService.createStyleElement(
+            `del{text-decoration: line-through; background-color:#fdb8c0 } ins{ text-decoration: underline; background-color: #ddffdd}`
+        );
+    }
 
     ngOnChanges(): void {
-        this.url = `/html/portlet/ext/htmlpages/view_live_working_diff.jsp?id=${this.pageId}&pageLang=${this.languageId}`;
+        this.dotEditPageService
+            .whatChange(this.pageId, this.languageId)
+            .pipe(take(1))
+            .subscribe((data) => {
+                this.whatsChanged = data;
+                if (this.whatsChanged.diff) {
+                    const doc = this.getEditPageDocument();
+                    doc.open();
+                    doc.write(
+                        this.updateHtml(
+                            this.dotDiffPipe.transform(
+                                this.whatsChanged.renderLive,
+                                this.whatsChanged.renderWorking
+                            )
+                        )
+                    );
+                    doc.head.appendChild(this.styles);
+                    doc.close();
+                }
+            });
+    }
+
+    private getEditPageDocument(): Document {
+        return (
+            this.dotIframe.iframeElement.nativeElement.contentDocument ||
+            this.dotIframe.iframeElement.nativeElement.contentWindow.document
+        );
+    }
+
+    private updateHtml(content: string): string {
+        const fakeHtml = document.createElement('html');
+        fakeHtml.innerHTML = content;
+        return fakeHtml.innerHTML;
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.module.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.module.ts
@@ -2,9 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DotWhatsChangedComponent } from './dot-whats-changed.component';
 import { IFrameModule } from '@components/_common/iframe';
+import { DotDiffPipeModule } from '@pipes/dot-diff/dot-diff.pipe.module';
+import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 
 @NgModule({
-    imports: [CommonModule, IFrameModule],
+    imports: [CommonModule, IFrameModule, DotDiffPipeModule, DotMessagePipeModule],
     declarations: [DotWhatsChangedComponent],
     exports: [DotWhatsChangedComponent]
 })

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -456,7 +456,6 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
             this.dotEditContentHtmlService.initEditMode(pageState, this.iframe);
             this.isEditMode = true;
         } else {
-            ``;
             this.dotEditContentHtmlService.renderPage(pageState, this.iframe);
             this.isEditMode = false;
         }

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -250,7 +250,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
 
     /**
      * Handle add Form ContentType from Content Palette.
-     * 
+     *
      * @memberof DotEditContentComponent
      */
     addFormContentType(): void {
@@ -337,20 +337,20 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
         };
         this.dotEditContentHtmlService.setContainterToAppendContentlet(container);
 
-        if( $event.data.contentType.variable !== 'forms' ) {
-        this.dotContentletEditorService
-            .getActionUrl($event.data.contentType.variable)
-            .pipe(take(1))
-            .subscribe((url) => {
-                this.dotContentletEditorService.create({
-                    data: { url },
-                    events: {
-                        load: (event) => {
-                            event.target.contentWindow.ngEditContentletEvents = this.dotEditContentHtmlService.contentletEvents$;
+        if ($event.data.contentType.variable !== 'forms') {
+            this.dotContentletEditorService
+                .getActionUrl($event.data.contentType.variable)
+                .pipe(take(1))
+                .subscribe((url) => {
+                    this.dotContentletEditorService.create({
+                        data: { url },
+                        events: {
+                            load: (event) => {
+                                event.target.contentWindow.ngEditContentletEvents = this.dotEditContentHtmlService.contentletEvents$;
+                            }
                         }
-                    }
+                    });
                 });
-            });
         } else {
             this.addFormContentType();
         }
@@ -456,6 +456,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
             this.dotEditContentHtmlService.initEditMode(pageState, this.iframe);
             this.isEditMode = true;
         } else {
+            ``;
             this.dotEditContentHtmlService.renderPage(pageState, this.iframe);
             this.isEditMode = false;
         }

--- a/apps/dotcms-ui/src/app/shared/models/dot-what-changed/dot-what-changed.model.ts
+++ b/apps/dotcms-ui/src/app/shared/models/dot-what-changed/dot-what-changed.model.ts
@@ -1,0 +1,5 @@
+export interface DotWhatChanged {
+    diff: boolean;
+    renderLive: string;
+    renderWorking: string;
+}

--- a/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.scss
+++ b/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.scss
@@ -1,9 +1,11 @@
+@use "variables" as *;
+
 ::ng-deep {
     del {
-        background-color: #fdb8c0;
+        background-color: $deleted-content-color;
     }
 
     ins {
-        background-color: #ddffdd;
+        background-color: $new-content-color;
     }
 }

--- a/libs/dot-primeng-theme-styles/src/scss/_variables.scss
+++ b/libs/dot-primeng-theme-styles/src/scss/_variables.scss
@@ -15,6 +15,8 @@ $gray-light: #b3b1b8;
 $gray-lighter: #e2e2e2;
 $gray-bg: #f1f3f4;
 $gray-hover: #eee;
+$deleted-content-color: #fdb8c0;
+$new-content-color: #ddffdd;
 
 $white_rgb: var(--color-white_rgb);
 $brand-primary: var(--color-main);


### PR DESCRIPTION
### Proposed Changes
* Replace What's changed with the htmldiff js library
* We need to remove daisydiff from our core code base and instead use the HTMLDiff tool in EditMode to provide the "what's changed" functionality.
* 
### Checklist
- [X ] Tests
- [ X] Translations