### PR TITLE
dotCMS/core#21240 Replace the growl of saving content in a page 

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -163,7 +163,8 @@ xdescribe('DotEditContentHtmlService', () => {
         'editpage.content.container.menu.content': 'Content',
         'editpage.content.container.menu.widget': 'Widget',
         'editpage.content.container.menu.form': 'Form',
-        'editpage.inline.error': 'An error ocurred'
+        'editpage.inline.error': 'An error ocurred',
+        'dot.common.message.saved': 'All changes Saved'
     });
 
     let service: DotEditContentHtmlService;
@@ -963,6 +964,7 @@ xdescribe('DotEditContentHtmlService', () => {
 
         it('should call saveContentlet and save the content', () => {
             spyOn(dotWorkflowActionsFireService, 'saveContentlet').and.returnValue(of({}));
+            spyOn(dotGlobalMessageService, 'success');
             const fakeElem: HTMLElement = fakeDocument.querySelector(
                 '[data-test-id="inline-edit-element-title"]'
             );
@@ -987,6 +989,8 @@ xdescribe('DotEditContentHtmlService', () => {
                 title: '<div>hello</div>',
                 inode: '999'
             });
+
+            expect(dotGlobalMessageService.success).toHaveBeenCalledOnceWith('All changes Saved');
         });
 
         it('should not call saveContentlet if isNotDirty is true', () => {

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -102,7 +102,7 @@ export class DotEditContentHtmlService {
 
     /**
      * Set the current page
-     * 
+     *
      * @param DotPage page
      */
     setCurrentPage(page: DotPage) {
@@ -203,7 +203,6 @@ export class DotEditContentHtmlService {
                     uuid: containerEl.dataset.dotUuid
                 };
 
-                
                 this.dotContainerContentletService
                     .getContentletToContainer(container, contentlet, this.currentPage)
                     .pipe(take(1))
@@ -624,6 +623,9 @@ export class DotEditContentHtmlService {
                         // on success
                         content.element.classList.remove('inline-editing--saving');
                         delete this.inlineCurrentContent[content.element.id];
+                        this.dotGlobalMessageService.success(
+                            this.dotMessageService.get('dot.common.message.saved')
+                        );
                     },
                     (e: HttpErrorResponse) => {
                         // on error
@@ -787,7 +789,11 @@ export class DotEditContentHtmlService {
         };
 
         this.dotContainerContentletService
-            .getContentletToContainer(relocateInfo.container, relocateInfo.contentlet, this.currentPage)
+            .getContentletToContainer(
+                relocateInfo.container,
+                relocateInfo.contentlet,
+                this.currentPage
+            )
             .subscribe((contentletHtml: string) => {
                 const newContentletEl: HTMLElement = this.generateNewContentlet(contentletHtml);
                 container.replaceChild(newContentletEl, contenletEl);


### PR DESCRIPTION
### Proposed Changes
* show global message "All Content Saved" on inline editing. 