### PR TITLE
dotCMS/core#19837 Fix PrimeNG class name change

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.html
@@ -21,7 +21,7 @@
 <form #form="ngForm" [formGroup]="myFormGroup" class="p-fluid" novalidate>
     <div #formContainer class="dot-apps-configuration-detail__form">
         <div
-            class="p-field"
+            class="field"
             *ngFor="let field of formFields"
             [attr.data-testid]="field.name"
             [ngSwitch]="field.type"

--- a/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.html
@@ -10,7 +10,7 @@
 >
     <form [formGroup]="form" [ngSwitch]="action" novalidate>
         <ng-container *ngSwitchCase="'Export'">
-            <div class="p-field">
+            <div class="field">
                 <label class="form__label" for="export-password">{{ 'Password' | dm }}</label>
                 <input
                     dotAutofocus
@@ -26,7 +26,7 @@
             </div>
         </ng-container>
         <ng-container *ngSwitchCase="'Import'">
-            <div class="p-field">
+            <div class="field">
                 <label class="form__label" for="import-file">{{ 'Upload-File' | dm }}</label>
                 <input
                     #importFile
@@ -36,7 +36,7 @@
                     (change)="onFileChange($event.target.files)"
                 />
             </div>
-            <div class="p-field">
+            <div class="field">
                 <label class="form__label" for="import-password">{{ 'Password' | dm }}</label>
                 <input
                     id="import-password"

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.html
@@ -5,7 +5,7 @@
     (save)="onSave()"
 >
     <form class="p-fluid" [formGroup]="form" data-testId="form" *ngIf="form">
-        <div class="p-field" data-testId="titleField">
+        <div class="field" data-testId="titleField">
             <label for="title" class="p-label-input-required">{{
                 'templates.properties.form.label.title' | dm
             }}</label>
@@ -20,14 +20,14 @@
                 [field]="form.get('title')"
             ></dot-field-validation-message>
         </div>
-        <div class="p-field" data-testId="descriptionField">
+        <div class="field" data-testId="descriptionField">
             <label for="description">{{
                 'templates.properties.form.label.description' | dm
             }}</label>
             <textarea id="description" pInputTextarea formControlName="friendlyName"></textarea>
         </div>
         <ng-container *ngIf="form.get('theme')">
-            <div class="p-field" data-testId="themeField">
+            <div class="field" data-testId="themeField">
                 <label class="p-label-input-required" for="theme">{{
                     'templates.properties.form.label.theme' | dm
                 }}</label>
@@ -38,7 +38,7 @@
                 ></dot-theme-selector-dropdown>
             </div>
         </ng-container>
-        <div class="p-field" data-testId="thumbnailField">
+        <div class="field" data-testId="thumbnailField">
             <label for="thumbnail">{{ 'templates.properties.form.label.thumbnail' | dm }}</label>
             <dot-template-thumbnail-field formControlName="image"></dot-template-thumbnail-field>
         </div>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/categories-property/categories-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/categories-property/categories-property.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" class="p-field">
+<div [formGroup]="group" class="field">
     <label class="form__label">{{ 'categories' | dm }} *</label>
     <dot-searchable-dropdown
         #searchableDropdown

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/data-type-property/data-type-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/data-type-property/data-type-property.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" *ngIf="radioInputs" class="p-field">
+<div [formGroup]="group" *ngIf="radioInputs" class="field">
     <label class="form__label">{{ 'contenttypes.field.properties.data_type.label' | dm }}</label>
 
     <div class="p-formgroup-inline">

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/default-value-property/default-value-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/default-value-property/default-value-property.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" class="p-field">
+<div [formGroup]="group" class="field">
     <label class="form__label">{{
         'contenttypes.field.properties.default_value.label' | dm
     }}</label>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.html
@@ -1,4 +1,4 @@
-<div class="p-field">
+<div class="field">
     <label for="" class="form__label"
         >{{ 'contenttypes.field.properties.relationships.contentType.label' | dm }}*</label
     >
@@ -20,7 +20,7 @@
     >
     </dot-searchable-dropdown>
 </div>
-<div class="p-field">
+<div class="field">
     <label for="" class="form__label">{{
         'contenttypes.field.properties.relationships.label' | dm
     }}</label>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.html
@@ -1,4 +1,4 @@
-<div class="p-field relationship__type" *ngIf="!editing">
+<div class="field relationship__type" *ngIf="!editing">
     <p-radioButton
         [label]="'contenttypes.field.properties.relationship.new.label' | dm"
         [value]="STATUS_NEW"
@@ -28,7 +28,7 @@
     </dot-new-relationships>
 
     <ng-template #existing>
-        <div class="p-field">
+        <div class="field">
             <label for="" class="form__label">Relationship</label>
             <dot-edit-relationships class="relationships__existing" (change)="handleChange($event)">
             </dot-edit-relationships>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/hint-property/hint-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/hint-property/hint-property.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" class="p-field">
+<div [formGroup]="group" class="field">
     <label class="form__label">{{ 'contenttypes.field.properties.hint.label' | dm }}</label>
     <input pInputText type="text" [formControlName]="property.name" />
 </div>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/name-property/name-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/name-property/name-property.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" class="p-field">
+<div [formGroup]="group" class="field">
     <label class="form__label"> {{ 'contenttypes.field.properties.name.label' | dm }} * </label>
     <input
         class="name__input"

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" class="p-field">
+<div [formGroup]="group" class="field">
     <label class="form__label">{{
         'contenttypes.field.properties.validation_regex.label' | dm
     }}</label>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/values-property/values-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/values-property/values-property.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" class="p-field">
+<div [formGroup]="group" class="field">
     <dot-field-helper
         *ngIf="helpText && isValidHelperClass()"
         [message]="helpText"

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="form" class="content-type__form p-fluid" id="content-type-form" novalidate>
-    <div class="p-field form__group--validation">
+    <div class="field form__group--validation">
         <label for="content-type-form-name">{{ nameFieldLabel }}</label>
         <input
             pInputText
@@ -16,7 +16,7 @@
             [field]="form.get('name')"
         ></dot-field-validation-message>
     </div>
-    <div class="p-field">
+    <div class="field">
         <label for="content-type-form-description">{{ 'contenttypes.form.label.icon' | dm }}</label>
         <dot-md-icon-selector
             id="content-type-form-icon"
@@ -24,7 +24,7 @@
         ></dot-md-icon-selector>
     </div>
 
-    <div class="p-field">
+    <div class="field">
         <label for="content-type-form-description">{{
             'contenttypes.form.label.description' | dm
         }}</label>
@@ -37,7 +37,7 @@
             [tabindex]="2"
         />
     </div>
-    <div class="p-field">
+    <div class="field">
         <label for="content-type-form-host" class="form__label">{{
             'contenttypes.form.field.host_folder.label' | dm
         }}</label>
@@ -48,7 +48,7 @@
             [tabindex]="3"
         ></dot-site-selector-field>
     </div>
-    <div class="p-field">
+    <div class="field">
         <label for="content-type-form-workflow" class="form__label">{{
             'contenttypes.form.label.workflow' | dm
         }}</label>
@@ -57,7 +57,7 @@
             formControlName="workflows"
         ></dot-workflows-selector-field>
     </div>
-    <div class="p-field" formGroupName="systemActionMappings">
+    <div class="field" formGroupName="systemActionMappings">
         <label for="content-type-form-workflow" class="form__label">{{
             'contenttypes.form.label.workflow.actions' | dm
         }}</label>
@@ -70,7 +70,7 @@
         'contenttypes.form.hint.error.only.default.scheme.available.in.Community' | dm
     }}</span>
     <div class="p-formgrid grid">
-        <div class="p-field p-col">
+        <div class="field p-col">
             <label for="content-type-form-publish-date-field" class="form__label">{{
                 'contenttypes.form.label.publish.date.field' | dm
             }}</label>
@@ -85,7 +85,7 @@
                 [tabindex]="5"
             ></p-dropdown>
         </div>
-        <div class="p-field p-col">
+        <div class="field p-col">
             <label for="content-type-form-expire-date-field" class="form__label">{{
                 'contenttypes.form.field.expire.date.field' | dm
             }}</label>
@@ -102,13 +102,13 @@
         </div>
     </div>
 
-    <div class="p-field">
+    <div class="field">
         <small class="p-field-hint" *ngIf="!dateVarOptions.length" id="field-dates-hint">{{
             'contenttypes.form.message.no.date.fields.defined' | dm
         }}</small>
     </div>
 
-    <div class="p-field" *ngIf="form.get('detailPage')">
+    <div class="field" *ngIf="form.get('detailPage')">
         <dot-page-selector
             id="content-type-form-detail-page"
             formControlName="detailPage"
@@ -116,7 +116,7 @@
             [label]="'contenttypes.form.field.detail.page' | dm"
         ></dot-page-selector>
     </div>
-    <div class="p-field form__group--helper" *ngIf="form.get('urlMapPattern')">
+    <div class="field form__group--helper" *ngIf="form.get('urlMapPattern')">
         <dot-field-helper
             [message]="'contenttypes.hint.URL.map.pattern.hint1' | dm"
         ></dot-field-helper>

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-add-to-bundle/dot-add-to-bundle.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-add-to-bundle/dot-add-to-bundle.component.html
@@ -12,7 +12,7 @@
         #formEl="ngForm"
         class="p-fluid"
     >
-        <div class="p-field">
+        <div class="field">
             <p-dropdown
                 #addBundleDropdown
                 appendTo="body"

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-download-bundle-dialog/dot-download-bundle-dialog.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-download-bundle-dialog/dot-download-bundle-dialog.component.html
@@ -11,7 +11,7 @@
         (keyup.enter)="handleSubmit()"
         class="p-fluid"
     >
-        <div class="p-field">
+        <div class="field">
             <label class="form__label">{{ 'download.bundle.i.want' | dm }}: </label>
             <p-selectButton
                 class="p-button-tabbed"
@@ -20,7 +20,7 @@
             >
             </p-selectButton>
         </div>
-        <div class="p-field">
+        <div class="field">
             <label class="form__label">{{ 'download.bundle.filter' | dm }}: </label>
             <p-dropdown
                 [options]="filterOptions"

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.html
@@ -1,4 +1,4 @@
-<div class="p-field">
+<div class="field">
     <label class="form__label">{{ label }}</label>
     <p-autoComplete
         #autoComplete
@@ -13,22 +13,28 @@
         field="label"
         [ngModel]="val"
         [suggestions]="suggestions$ | async"
-        [placeholder]=" 'page.selector.placeholder' | dm"
+        [placeholder]="'page.selector.placeholder' | dm"
     >
         <ng-template let-item pTemplate="item">
             <div class="dot-page-selector__item">
-                <span *ngIf="searchType === 'site'; else notSite" >{{ item.label }}</span>
+                <span *ngIf="searchType === 'site'; else notSite">{{ item.label }}</span>
                 <ng-template #notSite>
                     <span class="dot-page-selector__item-url">
                         {{ item.payload.path }}
                     </span>
                     <span class="dot-page-selector__item-host">
-                        {{item.payload.hostName}}
+                        {{ item.payload.hostName }}
                     </span>
                 </ng-template>
             </div>
         </ng-template>
     </p-autoComplete>
-    <small data-testId="message" [class]=" isError ? 'p-invalid' : 'p-info'" [textContent]="message"></small>
-    <dot-field-helper [message]=" (folderSearch ? 'page.selector.folder.hint' : 'page.selector.hint') | dm"></dot-field-helper>
+    <small
+        data-testId="message"
+        [class]="isError ? 'p-invalid' : 'p-info'"
+        [textContent]="message"
+    ></small>
+    <dot-field-helper
+        [message]="(folderSearch ? 'page.selector.folder.hint' : 'page.selector.hint') | dm"
+    ></dot-field-helper>
 </div>

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
@@ -6,7 +6,7 @@
     novalidate
     class="p-fluid"
 >
-    <div class="p-field" *ngIf="data['assignable']">
+    <div class="field" *ngIf="data['assignable']">
         <label class="form__label">{{ 'assignee.form.assignee' | dm }}:</label>
         <p-dropdown
             [options]="dotRoles"
@@ -16,7 +16,7 @@
         >
         </p-dropdown>
     </div>
-    <div class="p-field" *ngIf="data['commentable']">
+    <div class="field" *ngIf="data['commentable']">
         <label class="form__label">{{ 'comment.form.comments' | dm }}:</label>
         <textarea
             pInputTextarea
@@ -27,13 +27,11 @@
         </textarea>
     </div>
 
-    <div class="p-field" *ngIf="data['moveable']" >
+    <div class="field" *ngIf="data['moveable']">
         <dot-page-selector
             formControlName="pathToMove"
             [folderSearch]="true"
             [label]="'Move' | dm"
         ></dot-page-selector>
     </div>
-
-
 </form>

--- a/apps/dotcms-ui/src/app/view/components/_common/forms/dot-push-publish-form/dot-push-publish-form.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/forms/dot-push-publish-form/dot-push-publish-form.component.html
@@ -7,7 +7,7 @@
     #formEl="ngForm"
     class="p-fluid"
 >
-    <div class="p-field">
+    <div class="field">
         <label class="form__label"
             >{{ 'contenttypes.content.push_publish.I_want_To' | dm }}:
         </label>
@@ -19,7 +19,7 @@
         </p-selectButton>
     </div>
 
-    <div class="p-field">
+    <div class="field">
         <label class="form__label">{{ 'contenttypes.content.push_publish.filters' | dm }}: </label>
         <p-dropdown
             [options]="filterOptions"
@@ -28,8 +28,8 @@
         ></p-dropdown>
     </div>
 
-    <div class="p-field form-group__two-cols push-publish-dialog__publish-dates-container">
-        <div class="p-field push-publish-dialog__publish-date">
+    <div class="field form-group__two-cols push-publish-dialog__publish-dates-container">
+        <div class="field push-publish-dialog__publish-date">
             <label class="form__label"
                 >{{ 'contenttypes.content.push_publish.publish_date' | dm }}:
             </label>
@@ -51,7 +51,7 @@
                 [field]="form.get('publishDate')"
             ></dot-field-validation-message>
         </div>
-        <div class="p-field push-publish-dialog__expire-date">
+        <div class="field push-publish-dialog__expire-date">
             <label class="form__label"
                 >{{ 'contenttypes.content.push_publish.expire_date' | dm }}:
             </label>
@@ -73,11 +73,11 @@
             ></dot-field-validation-message>
         </div>
     </div>
-    <div class="p-field push-publish-dialog__timezone-label">
+    <div class="field push-publish-dialog__timezone-label">
         <span>{{ localTimezone }}</span> -
         <a href="#" (click)="toggleTimezonePicker($event)"> {{ changeTimezoneActionLabel }}</a>
     </div>
-    <div class="p-field" data-testid="timeZoneSelectContainer" [hidden]="!showTimezonePicker">
+    <div class="field" data-testid="timeZoneSelectContainer" [hidden]="!showTimezonePicker">
         <label class="form__label">{{ 'time-zone' | dm }}: </label>
         <p-dropdown
             data-testid="timeZoneSelect"
@@ -89,7 +89,7 @@
             appendTo="body"
         ></p-dropdown>
     </div>
-    <div class="p-field">
+    <div class="field">
         <label class="form__label">{{ 'contenttypes.content.push_publish.push_to' | dm }}: </label>
         <dot-push-publish-env-selector
             [assetIdentifier]="assetIdentifier"

--- a/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="form" class="p-fluid">
-    <div class="p-field">
+    <div class="field">
         <label for="content-type-form-host" class="form__label">{{
             'modes.persona.host' | dm
         }}</label>
@@ -10,7 +10,7 @@
         ></dot-site-selector-field>
     </div>
 
-    <div class="p-field">
+    <div class="field">
         <label for="persona-name" class="form__label">{{ 'modes.persona.name' | dm }}</label>
         <input
             id="persona-name"
@@ -28,12 +28,12 @@
         </dot-field-validation-message>
     </div>
 
-    <div class="p-field">
+    <div class="field">
         <label for="persona-keyTag" class="form__label">{{ 'modes.persona.key.tag' | dm }}</label>
         <input id="persona-keyTag" type="text" formControlName="keyTag" name="keyTag" pInputText />
     </div>
 
-    <div class="p-field">
+    <div class="field">
         <label for="persona-image" class="form__label">{{
             'modes.persona.upload.file' | dm
         }}</label>
@@ -60,7 +60,7 @@
             ></button>
         </div>
     </div>
-    <div class="p-field">
+    <div class="field">
         <label for="persona-other-tags" class="form__label">{{
             'modes.persona.other.tags' | dm
         }}</label>

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-edit-layout-grid/dot-edit-layout-grid.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-edit-layout-grid/dot-edit-layout-grid.component.html
@@ -50,7 +50,7 @@
     [width]="400"
 >
     <form *ngIf="addClassDialogShow" [formGroup]="form" novalidate class="p-fluid">
-        <div class="p-field">
+        <div class="field">
             <label>{{ 'editpage.layout.css.class.names' | dm }}</label>
             <input
                 class="box__add-class-text"

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-layout-properties/dot-layout-properties.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-layout-properties/dot-layout-properties.component.html
@@ -1,5 +1,5 @@
 <p-overlayPanel #op appendTo="body" styleClass="dot-layout-properties__overlayPanel">
-    <div [formGroup]="group" class="p-field">
+    <div [formGroup]="group" class="field">
         <dot-layout-properties-item
             [label]="'editpage.layout.properties.header' | dm"
             class="property-item__header"

--- a/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.html
@@ -15,7 +15,7 @@
             novalidate
             class="p-fluid"
         >
-            <div class="p-field">
+            <div class="field">
                 <!--TODO: get rid of this let autoComplete when this is fixed: https://github.com/primefaces/primeng/issues/745-->
                 <dot-searchable-dropdown
                     #searchableDropdown
@@ -33,7 +33,7 @@
                 >
                 </dot-searchable-dropdown>
             </div>
-            <div class="p-field" *ngIf="needPassword">
+            <div class="field" *ngIf="needPassword">
                 <input
                     pPassword
                     #password

--- a/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.html
@@ -12,7 +12,7 @@
     ></div>
 
     <form #myAccountForm="ngForm" class="my-account p-fluid">
-        <div class="p-field">
+        <div class="field">
             <label for="dot-my-account-first-name-input">{{ 'First-Name' | dm }}</label>
             <input
                 pInputText
@@ -28,7 +28,7 @@
             </small>
         </div>
 
-        <div class="p-field">
+        <div class="field">
             <label for="dot-my-account-first-name-input">{{ 'Last-Name' | dm }}</label>
             <input
                 pInputText
@@ -44,7 +44,7 @@
             </small>
         </div>
 
-        <div class="p-field">
+        <div class="field">
             <label for="dot-my-account-email-input">{{ 'email-address' | dm }}</label>
             <input
                 pInputText
@@ -67,7 +67,7 @@
             </small>
         </div>
 
-        <div class="p-field">
+        <div class="field">
             <p-checkbox
                 #showStarterCheckbox
                 data-testid="showStarterBtn"
@@ -79,7 +79,7 @@
             </p-checkbox>
         </div>
 
-        <div class="p-field">
+        <div class="field">
             <label for="dot-my-account-current-password-input">{{ 'current-password' | dm }}</label>
             <input
                 pPassword
@@ -93,7 +93,7 @@
                 required
             />
         </div>
-        <div class="p-field">
+        <div class="field">
             <p-checkbox
                 (onChange)="toggleChangePasswordOption()"
                 binary="true"
@@ -102,7 +102,7 @@
             >
             </p-checkbox>
         </div>
-        <div class="p-field">
+        <div class="field">
             <label>{{ 'new-password' | dm }}</label>
             <input
                 pPassword
@@ -115,7 +115,7 @@
                 [disabled]="!changePasswordOption"
             />
         </div>
-        <div class="p-field">
+        <div class="field">
             <label for="dot-my-account-confirm-new-password-input">{{
                 're-enter-new-password' | dm
             }}</label>

--- a/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.html
+++ b/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.html
@@ -26,7 +26,7 @@
             data-testId="message"
             [innerHTML]="message"
         ></p>
-        <div class="p-field form__group--validation">
+        <div class="field form__group--validation">
             <label data-testId="emailLabel" for="inputtext">{{
                 loginInfo.i18nMessagesMap['emailAddressLabel']
             }}</label>
@@ -53,7 +53,7 @@
             >
             </dot-field-validation-message>
         </div>
-        <div class="p-field form__group--validation">
+        <div class="field form__group--validation">
             <label data-testId="passwordLabel" for="inputtext">{{
                 loginInfo.i18nMessagesMap['password']
             }}</label>
@@ -77,7 +77,7 @@
             >
             </dot-field-validation-message>
         </div>
-        <div class="login__password-settings p-field">
+        <div class="login__password-settings field">
             <p-checkbox
                 formControlName="rememberMe"
                 data-testId="rememberMe"
@@ -92,7 +92,7 @@
                 >{{ loginInfo.i18nMessagesMap['get-new-password'] }}</a
             >
         </div>
-        <div class="p-field">
+        <div class="field">
             <dot-loading-indicator></dot-loading-indicator>
             <button
                 [disabled]="!loginForm.valid"

--- a/apps/dotcms-ui/src/app/view/components/login/forgot-password-component/forgot-password.component.html
+++ b/apps/dotcms-ui/src/app/view/components/login/forgot-password-component/forgot-password.component.html
@@ -2,7 +2,7 @@
     <h3 data-testId="header">{{ loginInfo.i18nMessagesMap['forgot-password'] }}</h3>
     <p class="p-invalid" data-testId="errorMessage" [innerHTML]="message"></p>
     <form [formGroup]="forgotPasswordForm" class="p-fluid">
-        <div class="p-field form__group--validation">
+        <div class="field form__group--validation">
             <label data-testId="usernameLabel" for="username">{{
                 loginInfo.i18nMessagesMap['emailAddressLabel']
             }}</label>
@@ -26,7 +26,7 @@
             >
             </dot-field-validation-message>
         </div>
-        <div class="p-field">
+        <div class="field">
             <button
                 pButton
                 class="p-button-secondary"

--- a/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.html
+++ b/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.html
@@ -2,7 +2,7 @@
     <h3 data-testId="header">{{ loginInfo.i18nMessagesMap['reset-password'] }}</h3>
     <p class="error-message p-invalid" data-testid="errorMessage" [innerHTML]="message"></p>
     <form [formGroup]="resetPasswordForm" class="p-fluid">
-        <div class="p-field form__group--validation">
+        <div class="field form__group--validation">
             <label data-testId="enterLabel">{{
                 loginInfo.i18nMessagesMap['enter-password']
             }}</label>
@@ -24,7 +24,7 @@
             >
             </dot-field-validation-message>
         </div>
-        <div class="p-field form__group--validation">
+        <div class="field form__group--validation">
             <label data-testId="confirmLabel">{{
                 loginInfo.i18nMessagesMap['re-enter-password']
             }}</label>
@@ -46,7 +46,7 @@
             >
             </dot-field-validation-message>
         </div>
-        <div class="p-field">
+        <div class="field">
             <button
                 type="submit"
                 pButton


### PR DESCRIPTION
### Proposed Changes
* PrimeNG change their `p-field` classname for `field` so we have to update our HTML accondingly.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
