### PR TITLE
dotCMS/core#Add backdrop-filter to our popup overlay background

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/dot-dialog/dot-dialog.component.scss
+++ b/apps/dotcms-ui/src/app/view/components/dot-dialog/dot-dialog.component.scss
@@ -7,6 +7,7 @@
 
     &.active {
         background-color: rgba($black, 0.8);
+        backdrop-filter: blur(5px);
         bottom: 0;
         display: block;
         left: 0;

--- a/libs/dot-primeng-theme-styles/src/scss/dotcms-theme/components/_dialog.scss
+++ b/libs/dot-primeng-theme-styles/src/scss/dotcms-theme/components/_dialog.scss
@@ -79,4 +79,5 @@
 
 .p-dialog-mask.p-component-overlay {
     background-color: rgba($black, 0.8);
+    backdrop-filter: blur(5px);
 }


### PR DESCRIPTION
### Proposed Changes
We want to make the app looks more "appy" (Jason's words) so for the overlay of the dialogs we want to add:

    backdrop-filter: blur(5px);

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
