### PR TITLE
dotCMS/core#21656 Once a fileAsset is saved. the file itself can not be replaced using Save

### DIFF
--- a/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
+++ b/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
@@ -58,7 +58,7 @@ export class DotContentletThumbnail {
     private getImageURL(): string {
         return this.contentlet.mimeType === 'application/pdf'
             ? `/contentAsset/image/${this.contentlet.inode}/${this.contentlet.titleImage}/pdf_page/1/resize_w/250/quality_q/45`
-            : `/dA/${this.contentlet.inode}/500w/20q`;
+            : `/dA/${this.contentlet.inode}/500w/20q?r=${this.contentlet.modDateMilis}`;
     }
 
     private switchToIcon(): any {

--- a/libs/dotcms-webcomponents/src/models/dot-contentlet-item.model.ts
+++ b/libs/dotcms-webcomponents/src/models/dot-contentlet-item.model.ts
@@ -33,4 +33,5 @@ export interface DotContentletItem {
     ownerCanPublish: string;
     mimeType: string;
     titleImage: string;
+    modDateMilis: number;
 }

--- a/libs/dotcms-webcomponents/src/test/mocks.ts
+++ b/libs/dotcms-webcomponents/src/test/mocks.ts
@@ -148,5 +148,6 @@ export const contentletMock: DotContentletItem = {
     mediaType: '',
     language: '',
     mimeType: '',
-    titleImage: 'fileAsset'
+    titleImage: 'fileAsset',
+    modDateMilis: 23434252456
 };


### PR DESCRIPTION
Cache the thumbnails with timestamp.

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
