### PR TITLE
dotCMS/core#21552 Add forms from content palette error 

### DIFF
--- a/libs/dotcms-field-elements/src/components/dot-form/dot-form-column/dot-form-column.tsx
+++ b/libs/dotcms-field-elements/src/components/dot-form/dot-form-column/dot-form-column.tsx
@@ -14,7 +14,9 @@ export class DotFormColumnComponent {
     @Prop({ reflect: true }) fieldsToShow: string;
 
     render() {
-        return this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field));
+        return this.column
+            ? this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field))
+            : null;
     }
 
     private getField(field: DotCMSContentTypeField): JSX.Element {

--- a/libs/dotcms-field-elements/src/components/dot-form/dot-form-column/dot-form-column.tsx
+++ b/libs/dotcms-field-elements/src/components/dot-form/dot-form-column/dot-form-column.tsx
@@ -14,6 +14,7 @@ export class DotFormColumnComponent {
     @Prop({ reflect: true }) fieldsToShow: string;
 
     render() {
+        // avoid error when column value is null.
         return this.column
             ? this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field))
             : null;

--- a/libs/dotcms-field-elements/src/components/dot-form/dot-form-column/dot-form-column.tsx
+++ b/libs/dotcms-field-elements/src/components/dot-form/dot-form-column/dot-form-column.tsx
@@ -14,7 +14,8 @@ export class DotFormColumnComponent {
     @Prop({ reflect: true }) fieldsToShow: string;
 
     render() {
-        // avoid error when column value is null.
+        // When the user start dragging a form in the edit page the value of layout of the
+        // <dot-form> element turns empty and eventually the column prop in this component
         return this.column
             ? this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field))
             : null;

--- a/libs/dotcms-field-elements/src/components/dot-form/dot-form-row/dot-form-row.tsx
+++ b/libs/dotcms-field-elements/src/components/dot-form/dot-form-row/dot-form-row.tsx
@@ -13,7 +13,8 @@ export class DotFormRowComponent {
     @Prop({ reflect: true }) fieldsToShow: string;
 
     render() {
-        // avoid error when row value is null.
+        // When the user start dragging a form in the edit page the value of layout of the
+        // <dot-form> element turns empty and eventually the row prop in this component
         return this.row
             ? this.row.columns.map((fieldColumn: DotCMSContentTypeLayoutColumn) => {
                   return (

--- a/libs/dotcms-field-elements/src/components/dot-form/dot-form-row/dot-form-row.tsx
+++ b/libs/dotcms-field-elements/src/components/dot-form/dot-form-row/dot-form-row.tsx
@@ -13,8 +13,13 @@ export class DotFormRowComponent {
     @Prop({ reflect: true }) fieldsToShow: string;
 
     render() {
-        return this.row.columns.map((fieldColumn: DotCMSContentTypeLayoutColumn) => {
-            return <dot-form-column column={fieldColumn} fields-to-show={this.fieldsToShow} />;
-        });
+        // avoid error when row value is null.
+        return this.row
+            ? this.row.columns.map((fieldColumn: DotCMSContentTypeLayoutColumn) => {
+                  return (
+                      <dot-form-column column={fieldColumn} fields-to-show={this.fieldsToShow} />
+                  );
+              })
+            : null;
     }
 }

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-column/dot-form-column.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-column/dot-form-column.tsx
@@ -16,7 +16,8 @@ export class DotFormColumnComponent {
     fieldsToShow: string;
 
     render() {
-        // avoid error when column value is null.
+        // When the user start dragging a form in the edit page the value of layout of the
+        // <dot-form> element turns empty and eventually the column prop in this component
         return this.column
             ? this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field))
             : null;

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-column/dot-form-column.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-column/dot-form-column.tsx
@@ -16,6 +16,7 @@ export class DotFormColumnComponent {
     fieldsToShow: string;
 
     render() {
+        // avoid error when column value is null.
         return this.column
             ? this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field))
             : null;

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-column/dot-form-column.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-column/dot-form-column.tsx
@@ -16,7 +16,9 @@ export class DotFormColumnComponent {
     fieldsToShow: string;
 
     render() {
-        return this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field));
+        return this.column
+            ? this.column.fields.map((field: DotCMSContentTypeField) => this.getField(field))
+            : null;
     }
 
     private getField(field: DotCMSContentTypeField): JSX.Element {

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-row/dot-form-row.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-row/dot-form-row.tsx
@@ -15,8 +15,12 @@ export class DotFormRowComponent {
     fieldsToShow: string;
 
     render() {
-        return this.row.columns.map((fieldColumn: DotCMSContentTypeLayoutColumn) => {
-            return <dot-form-column column={fieldColumn} fields-to-show={this.fieldsToShow} />;
-        });
+        return this.row
+            ? this.row.columns.map((fieldColumn: DotCMSContentTypeLayoutColumn) => {
+                  return (
+                      <dot-form-column column={fieldColumn} fields-to-show={this.fieldsToShow} />
+                  );
+              })
+            : null;
     }
 }

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-row/dot-form-row.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-row/dot-form-row.tsx
@@ -15,6 +15,7 @@ export class DotFormRowComponent {
     fieldsToShow: string;
 
     render() {
+        // avoid error when row value is null.
         return this.row
             ? this.row.columns.map((fieldColumn: DotCMSContentTypeLayoutColumn) => {
                   return (

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-row/dot-form-row.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/components/dot-form-row/dot-form-row.tsx
@@ -15,7 +15,8 @@ export class DotFormRowComponent {
     fieldsToShow: string;
 
     render() {
-        // avoid error when row value is null.
+        // When the user start dragging a form in the edit page the value of layout of the
+        // <dot-form> element turns empty and eventually the row prop in this component
         return this.row
             ? this.row.columns.map((fieldColumn: DotCMSContentTypeLayoutColumn) => {
                   return (


### PR DESCRIPTION
### Proposed Changes
* fix js errors when dragging the form evaluating undefined scenarios, reported here: https://github.com/dotCMS/core/issues/21552#issuecomment-1034297688

Scenario: When the user start dragging a form in the edit page the value of layout  of the `<dot-form>` element turns empty and the js errors show up. 

Fix: adding empty validation to avoid console errors. 