### PR TITLE
dotCMS/core#21612 fix Template Publish UI Suggestion

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.spec.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.spec.ts
@@ -185,6 +185,32 @@ describe('DotTemplatesService', () => {
             }
         });
     });
+    it('should put to save and publish a template', () => {
+        service
+            .saveAndPublish({
+                name: '',
+                anonymous: true,
+                friendlyName: ''
+            } as DotTemplate)
+            .subscribe((template) => {
+                expect(template as any).toEqual({
+                    identifier: '1234',
+                    name: 'Theme name'
+                });
+            });
+
+        const req = httpMock.expectOne(`${TEMPLATE_API_URL}_savepublish`);
+
+        expect(req.request.method).toBe('PUT');
+        expect(req.request.body).toEqual({ name: '', anonymous: true, friendlyName: '' });
+
+        req.flush({
+            entity: {
+                identifier: '1234',
+                name: 'Theme name'
+            }
+        });
+    });
     it('should delete a template', () => {
         service.delete(['testId01']).subscribe();
         const req = httpMock.expectOne(TEMPLATE_API_URL);

--- a/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
@@ -82,6 +82,19 @@ export class DotTemplatesService {
     }
 
     /**
+     * Save and Publish a template
+     * @returns Observable<DotTemplate>
+     * @memberof DotTemplatesService
+     */
+    saveAndPublish(values: DotTemplate): Observable<DotTemplate> {
+        return this.request<DotTemplate>({
+            method: 'PUT',
+            url: `${TEMPLATE_API_URL}_savepublish`,
+            body: values
+        });
+    }
+
+    /**
      * Delete a template
      * @param {string[]} identifiers
      * @returns Observable<DotActionBulkResult>

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
@@ -16,6 +16,7 @@
             <dot-edit-layout-designer
                 [theme]="item.theme"
                 [layout]="item.layout"
+                (saveAndPublish)="saveAndPublish.emit($event)"
                 (updateTemplate)="updateTemplate.emit($event)"
                 (save)="save.emit($event)"
             ></dot-edit-layout-designer>

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -39,6 +39,8 @@ class DotEditLayoutDesignerMockComponent {
     @Output() save: EventEmitter<Event> = new EventEmitter();
 
     @Output() updateTemplate: EventEmitter<Event> = new EventEmitter();
+
+    @Output() saveAndPublish: EventEmitter<Event> = new EventEmitter();
 }
 
 @Component({
@@ -177,7 +179,7 @@ describe('DotTemplateBuilderComponent', () => {
             expect(advanced).toBeNull();
         });
 
-        it('should emit events from dot-edit-layout-designer', () => {
+        it('should emit save events from dot-edit-layout-designer', () => {
             const builder = de.query(By.css('dot-edit-layout-designer'));
 
             builder.triggerEventHandler('save', EMPTY_TEMPLATE_DESIGN);
@@ -185,6 +187,13 @@ describe('DotTemplateBuilderComponent', () => {
 
             expect(component.save.emit).toHaveBeenCalledWith(EMPTY_TEMPLATE_DESIGN);
             expect(component.updateTemplate.emit).toHaveBeenCalledWith(EMPTY_TEMPLATE_DESIGN);
+        });
+
+        it('should emit save and publish event from dot-edit-layout-designer', () => {
+            spyOn(component.saveAndPublish, 'emit');
+            const builder = de.query(By.css('dot-edit-layout-designer'));
+            builder.triggerEventHandler('saveAndPublish', EMPTY_TEMPLATE_DESIGN);
+            expect(component.saveAndPublish.emit).toHaveBeenCalledWith(EMPTY_TEMPLATE_DESIGN);
         });
     });
 

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
@@ -18,6 +18,7 @@ import { IframeComponent } from '@components/_common/iframe/iframe-component';
 export class DotTemplateBuilderComponent implements OnInit, OnChanges {
     @Input() item: DotTemplateItem;
     @Input() didTemplateChanged: boolean;
+    @Output() saveAndPublish = new EventEmitter<DotTemplateItem>();
     @Output() updateTemplate = new EventEmitter<DotTemplateItem>();
     @Output() save = new EventEmitter<DotTemplateItem>();
     @Output() cancel = new EventEmitter();

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.html
@@ -14,15 +14,16 @@
             </ng-container>
         </dot-portlet-toolbar>
         <!-- The observable returns a boolen, therefore we can not use  *ngIf="obs$ | async as obs" to subscribe to it -->
-        <ng-container *ngIf="{ value: didTemplateChanged$ | async} as didTemplateChanged">
-        <dot-template-builder
-            [didTemplateChanged]="didTemplateChanged.value"
-            [item]="vm.working"
-            (updateTemplate)="updateWorkingTemplate($event)"
-            (save)="saveTemplate($event)"
-            (cancel)="cancelTemplate()"
-            (custom)="onCustomEvent($event)"
-        ></dot-template-builder>
+        <ng-container *ngIf="{ value: didTemplateChanged$ | async } as didTemplateChanged">
+            <dot-template-builder
+                [didTemplateChanged]="didTemplateChanged.value"
+                [item]="vm.working"
+                (updateTemplate)="updateWorkingTemplate($event)"
+                (saveAndPublish)="saveAndPublishTemplate($event)"
+                (save)="saveTemplate($event)"
+                (cancel)="cancelTemplate()"
+                (custom)="onCustomEvent($event)"
+            ></dot-template-builder>
         </ng-container>
     </dot-portlet-base>
 </ng-container>

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
@@ -443,6 +443,10 @@ describe('DotTemplateCreateEditComponent', () => {
                 };
                 const storeMock = {
                     ...templateStoreValue,
+                    saveTemplate: jasmine.createSpy(),
+                    saveAndPublishTemplate: jasmine.createSpy(),
+                    goToTemplateList: jasmine.createSpy(),
+                    goToEditTemplate: jasmine.createSpy(),
                     vm$: of({
                         working: template,
                         original: template,
@@ -552,6 +556,42 @@ describe('DotTemplateCreateEditComponent', () => {
                     };
 
                     expect(store.saveWorkingTemplate).toHaveBeenCalledWith(template);
+                });
+
+                it('should saveAndPublishTemplate', () => {
+                    const builder = de.query(By.css('dot-template-builder'));
+                    builder.triggerEventHandler('saveAndPublish', {
+                        layout: {
+                            title: '',
+                            width: '',
+                            footer: true,
+                            header: false,
+                            sidebar: {},
+                            body: {
+                                rows: []
+                            }
+                        },
+                        themeId: '123'
+                    });
+
+                    expect(store.saveAndPublishTemplate).toHaveBeenCalledWith({
+                        title: 'Some template',
+                        type: 'design',
+                        layout: {
+                            title: '',
+                            width: '',
+                            footer: true,
+                            header: false,
+                            sidebar: {},
+                            body: {
+                                rows: []
+                            }
+                        },
+                        identifier: '123',
+                        friendlyName: '',
+                        theme: '123',
+                        image: ''
+                    });
                 });
 
                 it('should cancel', () => {

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
@@ -75,46 +75,42 @@ export class DotTemplateCreateEditComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Update Working Tempalte
+     * Save and publish template to store
      *
+     * @param DotTemplate template
      * @memberof DotTemplateCreateEditComponent
      */
-    updateWorkingTemplate({ layout, body, themeId }: DotTemplate): void {
-        let value = {
+    saveAndPublishTemplate(template: DotTemplate): void {
+        this.store.saveAndPublishTemplate({
             ...this.form.value,
-            body
-        };
+            ...this.formatTemplateItem(template)
+        });
+    }
 
-        if (layout) {
-            value = {
-                ...this.form.value,
-                layout,
-                theme: themeId
-            };
-        }
-
-        this.store.saveWorkingTemplate(value);
+    /**
+     * Update Working Template
+     *
+     * @param DotTemplate template
+     * @memberof DotTemplateCreateEditComponent
+     */
+    updateWorkingTemplate(template: DotTemplate): void {
+        this.store.saveWorkingTemplate({
+            ...this.form.value,
+            ...this.formatTemplateItem(template)
+        });
     }
 
     /**
      * Save template to store
      *
+     * @param DotTemplate template
      * @memberof DotTemplateCreateEditComponent
      */
-    saveTemplate({ layout, body, themeId }: DotTemplate): void {
-        let value = {
+    saveTemplate(template: DotTemplate): void {
+        this.store.saveTemplate({
             ...this.form.value,
-            body
-        };
-
-        if (layout) {
-            value = {
-                ...this.form.value,
-                layout,
-                theme: themeId
-            };
-        }
-        this.store.saveTemplate(value);
+            ...this.formatTemplateItem(template)
+        });
     }
 
     /**
@@ -226,5 +222,22 @@ export class DotTemplateCreateEditComponent implements OnInit, OnDestroy {
             .subscribe(() => {
                 this.store.goToTemplateList();
             });
+    }
+
+    private formatTemplateItem({ layout, body, themeId }: DotTemplate): DotTemplateItem {
+        let value = {
+            ...this.form.value,
+            body
+        };
+
+        if (layout) {
+            value = {
+                ...this.form.value,
+                layout,
+                theme: themeId
+            };
+        }
+
+        return value;
     }
 }

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
@@ -20,7 +20,9 @@ import { mockResponseView } from '@dotcms/app/test/response-view.mock';
 
 const messageServiceMock = new MockDotMessageService({
     'dot.common.message.saved': 'saved',
-    'dot.common.message.saving': 'saving'
+    'dot.common.message.saving': 'saving',
+    publishing: 'publishing',
+    'message.template.published': 'published'
 });
 
 function getTemplate({ identifier, name, body }) {
@@ -93,6 +95,15 @@ const BASIC_PROVIDERS = [
                         body: '<h4>Hi you</h1>'
                     })
                 )
+            ),
+            saveAndPublish: jasmine.createSpy().and.returnValue(
+                of(
+                    getTemplate({
+                        identifier: '222-3000-333---30303-394',
+                        name: 'Saved and published template',
+                        body: '<h4>Hi you</h1>'
+                    })
+                )
             )
         }
     },
@@ -160,6 +171,17 @@ describe('DotTemplateStore', () => {
             dotTemplatesService = TestBed.inject(DotTemplatesService);
             dotHttpErrorManagerService = TestBed.inject(DotHttpErrorManagerService);
             dotEditLayoutService = TestBed.inject(DotEditLayoutService);
+            service.skipSave = false;
+
+            dotTemplatesService.update = jasmine.createSpy().and.returnValue(
+                of(
+                    getTemplate({
+                        identifier: '222-3000-333---30303-394',
+                        name: 'Updated template',
+                        body: '<h4>Hi you</h1>'
+                    })
+                )
+            );
         });
 
         it('should have basic state', (done) => {
@@ -253,6 +275,16 @@ describe('DotTemplateStore', () => {
             dotGlobalMessageService = TestBed.inject(DotGlobalMessageService);
             dotHttpErrorManagerService = TestBed.inject(DotHttpErrorManagerService);
             dotEditLayoutService = TestBed.inject(DotEditLayoutService);
+
+            dotTemplatesService.update = jasmine.createSpy().and.returnValue(
+                of(
+                    getTemplate({
+                        identifier: '222-3000-333---30303-394',
+                        name: 'Updated template',
+                        body: '<h4>Hi you</h1>'
+                    })
+                )
+            );
         });
 
         it('should have basic state', (done) => {
@@ -472,15 +504,13 @@ describe('DotTemplateStore', () => {
                 });
             });
 
-            it('should update template and update the state after 10 seconds', fakeAsync(() => {
-                service.saveTemplateDebounce({
+            it('should update template and update the state', () => {
+                service.saveTemplate({
                     body: 'string',
                     friendlyName: 'string',
                     identifier: 'string',
                     title: 'string'
                 });
-
-                tick(10000);
 
                 expect<any>(dotTemplatesService.update).toHaveBeenCalledWith({
                     body: 'string',
@@ -518,11 +548,57 @@ describe('DotTemplateStore', () => {
                         apiLink: '/api/v1/templates/2d87af36-a935-4689-b427-dea75e9d84cf/working'
                     });
                 });
-            }));
+            });
 
-            it('should call updateWorkingTemplate and call saveTemplateDebounce when is a design template', () => {
+            it('should save and publish template and update the state', () => {
+                service.saveAndPublishTemplate({
+                    body: 'string',
+                    friendlyName: 'string',
+                    identifier: 'string',
+                    title: 'string'
+                });
+
+                expect<any>(dotTemplatesService.saveAndPublish).toHaveBeenCalledWith({
+                    body: 'string',
+                    friendlyName: 'string',
+                    identifier: 'string',
+                    title: 'string'
+                });
+
+                expect(dotGlobalMessageService.loading).toHaveBeenCalledWith('publishing');
+                expect(dotGlobalMessageService.success).toHaveBeenCalledWith('published');
+                expect(dotRouterService.goToEditTemplate).toHaveBeenCalledWith(
+                    '222-3000-333---30303-394'
+                );
+
+                service.state$.subscribe((res) => {
+                    expect(res).toEqual({
+                        working: {
+                            type: 'advanced',
+                            identifier: '222-3000-333---30303-394',
+                            title: 'Saved and published template',
+                            friendlyName: '',
+                            drawed: false,
+                            body: '<h4>Hi you</h1>',
+                            image: ''
+                        },
+                        original: {
+                            type: 'advanced',
+                            identifier: '222-3000-333---30303-394',
+                            title: 'Saved and published template',
+                            friendlyName: '',
+                            drawed: false,
+                            body: '<h4>Hi you</h1>',
+                            image: ''
+                        },
+                        apiLink: '/api/v1/templates/2d87af36-a935-4689-b427-dea75e9d84cf/working'
+                    });
+                });
+            });
+
+            it('should call updateWorkingTemplate and call saveTemplate after 10 seconds when is a design template', fakeAsync(() => {
                 spyOn(service, 'updateWorkingTemplate');
-                spyOn(service, 'saveTemplateDebounce');
+                spyOn(service, 'saveTemplate');
                 service.saveWorkingTemplate({
                     type: 'design',
                     layout: {
@@ -538,30 +614,15 @@ describe('DotTemplateStore', () => {
                     identifier: 'string',
                     title: 'string'
                 });
+                tick(10000);
 
                 expect(service.updateWorkingTemplate).toHaveBeenCalled();
-                expect(service.saveTemplateDebounce).toHaveBeenCalled();
-            });
-            it('should call updateWorkingTemplate and not call saveTemplateDebounce when is a advanced template', () => {
-                spyOn(service, 'updateWorkingTemplate');
-                spyOn(service, 'saveTemplateDebounce');
-                service.saveWorkingTemplate({
-                    type: 'advanced',
-                    body: '',
-                    friendlyName: 'string',
-                    identifier: 'string',
-                    title: 'string'
-                });
-
-                // tick(10000);
-
-                expect(service.updateWorkingTemplate).toHaveBeenCalled();
-                expect(service.saveTemplateDebounce).not.toHaveBeenCalled();
-            });
+                expect(service.saveTemplate).toHaveBeenCalled();
+            }));
 
             it('should handler error on update template', (done) => {
                 const error = throwError(new HttpErrorResponse(mockResponseView(400)));
-                spyOn<any>(service, 'persistTemplate').and.returnValue(error);
+                dotTemplatesService.update = jasmine.createSpy().and.returnValue(error);
                 service.saveTemplate({
                     body: 'string',
                     friendlyName: 'string',
@@ -575,6 +636,22 @@ describe('DotTemplateStore', () => {
                     done();
                 });
             });
+
+            it('should call updateWorkingTemplate and not call saveTemplate after 10 seconds when is a advanced template', fakeAsync(() => {
+                spyOn(service, 'updateWorkingTemplate');
+                spyOn(service, 'saveTemplate');
+                service.saveWorkingTemplate({
+                    type: 'advanced',
+                    body: '',
+                    friendlyName: 'string',
+                    identifier: 'string',
+                    title: 'string'
+                });
+                tick(10000);
+
+                expect(service.updateWorkingTemplate).toHaveBeenCalled();
+                expect(service.saveTemplate).not.toHaveBeenCalled();
+            }));
 
             it('should not update template body when updates props', () => {
                 service.saveProperties({

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.html
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.html
@@ -44,6 +44,16 @@
             <dot-layout-properties [group]="form.get('layout')"></dot-layout-properties>
             <dot-icon-button [size]="32" float icon="add" (click)="addGridBox()"></dot-icon-button>
             <span class="toolbar__sep"></span>
+            <button
+                *ngIf="!apiLink"
+                pButton
+                class="p-button-secondary"
+                data-testid="publishBtn"
+                [disabled]="disablePublish"
+                type="button"
+                [label]="'Publish' | dm"
+                (click)="onSaveAndPublish()"
+            ></button>
             <input
                 #templateName
                 pInputText

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.spec.ts
@@ -159,6 +159,7 @@ describe('DotEditLayoutDesignerComponent', () => {
         beforeEach(() => {
             component.layout = mockDotLayout();
             component.theme = '123';
+            component.disablePublish = false;
             fixture.detectChanges();
         });
         // these need to be fixed when this is fixed correctly https://github.com/dotCMS/core/issues/18830
@@ -184,6 +185,12 @@ describe('DotEditLayoutDesignerComponent', () => {
             // TODO: NEED EXTRA EXPECTS
         });
 
+        it('should enable publish button when editing the form.', () => {
+            component.form.get('title').setValue('Hello');
+            fixture.detectChanges();
+            expect(component.disablePublish).toBe(false);
+        });
+
         it('should not show template name input', () => {
             const templateNameInput: DebugElement = fixture.debugElement.query(
                 By.css('.dot-edit-layout__toolbar-template-name')
@@ -196,6 +203,15 @@ describe('DotEditLayoutDesignerComponent', () => {
                 By.css('.dot-edit-layout__toolbar-save-template')
             );
             expect(checkboxSave).toBe(null);
+        });
+
+        it('should emit pushAndPublish event when button clicked', () => {
+            spyOn(component.saveAndPublish, 'emit').and.callThrough();
+            fixture.detectChanges();
+            const publishButton = fixture.debugElement.query(By.css('[data-testId="publishBtn"]'));
+            publishButton.triggerEventHandler('click', null);
+            fixture.detectChanges();
+            expect(component.saveAndPublish.emit).toHaveBeenCalledWith(component.form.value);
         });
 
         it('should save changes when closeEditLayout is true', () => {
@@ -217,7 +233,7 @@ describe('DotEditLayoutDesignerComponent', () => {
             const layoutProperties: DebugElement = fixture.debugElement.query(
                 By.css('dot-layout-properties')
             );
-            
+
             expect(layoutProperties).toBeTruthy();
             expect(layoutProperties.componentInstance.group).toEqual(component.form.get('layout'));
         });
@@ -282,8 +298,9 @@ describe('DotEditLayoutDesignerComponent', () => {
                 By.css('.dot-edit-layout__toolbar-action-themes')
             ).nativeElement;
             themeButton.click();
-            themeSelector = fixture.debugElement.query(By.css('dot-theme-selector'))
-                .componentInstance;
+            themeSelector = fixture.debugElement.query(
+                By.css('dot-theme-selector')
+            ).componentInstance;
             const themeSelectorBtn = fixture.debugElement.query(
                 By.css('.dot-edit-layout__toolbar-action-themes')
             ).nativeElement;
@@ -309,8 +326,9 @@ describe('DotEditLayoutDesignerComponent', () => {
                 By.css('.dot-edit-layout__toolbar-action-themes')
             ).nativeElement;
             themeButton.click();
-            themeSelector = fixture.debugElement.query(By.css('dot-theme-selector'))
-                .componentInstance;
+            themeSelector = fixture.debugElement.query(
+                By.css('dot-theme-selector')
+            ).componentInstance;
             const mockTheme = _.cloneDeep(mockDotThemes[0]);
             themeSelector.selected.emit(mockTheme);
             expect(component.changeThemeHandler).toHaveBeenCalledWith(mockTheme);

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.ts
@@ -70,6 +70,9 @@ export class DotEditLayoutDesignerComponent implements OnInit, OnDestroy, OnChan
     save: EventEmitter<DotTemplate> = new EventEmitter();
 
     @Output()
+    saveAndPublish: EventEmitter<Event> = new EventEmitter();
+
+    @Output()
     updateTemplate: EventEmitter<DotTemplate> = new EventEmitter();
 
     form: FormGroup;
@@ -79,6 +82,7 @@ export class DotEditLayoutDesignerComponent implements OnInit, OnDestroy, OnChan
     currentTheme: DotTheme;
 
     saveAsTemplate: boolean;
+    disablePublish = true;
     showTemplateLayoutSelectionDialog = false;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
@@ -129,6 +133,17 @@ export class DotEditLayoutDesignerComponent implements OnInit, OnDestroy, OnChan
      */
     onSave(): void {
         this.save.emit(this.form.value);
+    }
+
+    /**
+     * Emit publish event
+     *
+     * @memberof DotEditLayoutDesignerComponent
+     */
+
+    onSaveAndPublish(): void {
+        this.disablePublish = true;
+        this.saveAndPublish.emit(this.form.value);
     }
 
     /**
@@ -223,6 +238,7 @@ export class DotEditLayoutDesignerComponent implements OnInit, OnDestroy, OnChan
             })
         });
         this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+            this.disablePublish = false;
             if (!_.isEqual(this.form.value, this.initialFormValue)) {
                 this.updateTemplate.emit(this.form.value);
             }


### PR DESCRIPTION
Provide users the full workflow options within the template edit screen to avoid having to go back to the template portlet, particularly when they need to publish
Create a default option of "publish" when editing or creating a new template

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
