### PR TITLE
dotCMS/core#21815 UI problems with notifications 

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/dot-message-display/dot-message-display.component.scss
+++ b/apps/dotcms-ui/src/app/view/components/dot-message-display/dot-message-display.component.scss
@@ -25,6 +25,10 @@
                 margin: 0;
             }
         }
+
+        .p-toast.p-component {
+            z-index: 1100;
+        }
     }
 
     dot-icon {


### PR DESCRIPTION
Primeng added a new event `(@toastAnimation.done)` here https://github.com/primefaces/primeng/blob/master/src/app/components/toast/toast.ts#L306.

This is removing the auto z-index on animation end while some notifications still showing. 