### PR TITLE
dotCMS/core#21612 Make Publish button be enabled when template has not been published

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
@@ -15,6 +15,7 @@
         <ng-template #elseBlock>
             <dot-edit-layout-designer
                 [theme]="item.theme"
+                [disablePublish]="item.live"
                 [layout]="item.layout"
                 (saveAndPublish)="saveAndPublish.emit($event)"
                 (updateTemplate)="updateTemplate.emit($event)"

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -34,6 +34,8 @@ class DotEditLayoutDesignerMockComponent {
 
     @Input() layout;
 
+    @Input() disablePublish: boolean;
+
     @Output() cancel: EventEmitter<MouseEvent> = new EventEmitter();
 
     @Output() save: EventEmitter<Event> = new EventEmitter();
@@ -149,7 +151,8 @@ describe('DotTemplateBuilderComponent', () => {
         beforeEach(() => {
             component.item = {
                 ...EMPTY_TEMPLATE_DESIGN,
-                theme: '123'
+                theme: '123',
+                live: true
             };
             fixture.detectChanges();
         });
@@ -162,6 +165,7 @@ describe('DotTemplateBuilderComponent', () => {
         it('should show dot-edit-layout-designer and pass attr', () => {
             const builder = de.query(By.css('dot-edit-layout-designer')).componentInstance;
             expect(builder.theme).toBe('123');
+            expect(builder.disablePublish).toBe(true);
             expect(builder.layout).toEqual({
                 header: true,
                 footer: true,

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
@@ -333,6 +333,7 @@ describe('DotTemplateStore', () => {
                     friendlyName: '',
                     type: 'advanced',
                     drawed: false,
+                    live: true,
                     body: '<h1>Hello</h1>'
                 });
 
@@ -343,6 +344,7 @@ describe('DotTemplateStore', () => {
                             identifier: '23423-234as-sd-w3sd-sd-srzcxsd',
                             title: 'New advaced',
                             friendlyName: '',
+                            live: true,
                             drawed: false,
                             body: '<h1>Hello</h1>'
                         },
@@ -351,6 +353,7 @@ describe('DotTemplateStore', () => {
                             identifier: '23423-234as-sd-w3sd-sd-srzcxsd',
                             title: 'New advaced',
                             friendlyName: '',
+                            live: true,
                             drawed: false,
                             body: '<h1>Hello</h1>'
                         },

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.ts
@@ -36,6 +36,7 @@ interface DotTemplateItemDesign {
     friendlyName: string;
     identifier: string;
     layout: DotLayout;
+    live?: boolean;
     theme: string;
     title: string;
     type?: 'design';
@@ -47,6 +48,7 @@ interface DotTemplateItemadvanced {
     drawed?: boolean;
     friendlyName: string;
     identifier: string;
+    live?: boolean;
     title: string;
     type?: 'advanced';
     image?: string;
@@ -352,6 +354,7 @@ export class DotTemplateStore extends ComponentStore<DotTemplateState> {
                 theme: template.theme,
                 containers: template.containers,
                 drawed: true,
+                live: template.live,
                 image: template.image
             };
         } else {

--- a/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.ts
@@ -66,6 +66,9 @@ export class DotEditLayoutDesignerComponent implements OnInit, OnDestroy, OnChan
     @Input()
     url: string;
 
+    @Input()
+    disablePublish = true;
+
     @Output()
     save: EventEmitter<DotTemplate> = new EventEmitter();
 
@@ -82,7 +85,6 @@ export class DotEditLayoutDesignerComponent implements OnInit, OnDestroy, OnChan
     currentTheme: DotTheme;
 
     saveAsTemplate: boolean;
-    disablePublish = true;
     showTemplateLayoutSelectionDialog = false;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();


### PR DESCRIPTION
The Publish Button should be enabled at all times while the template is in a working state. And Not only while I make changes on the active editor.
Let's consider this scenario:
I open The Template editor remove a container and then leave the editor. then I reopen the template and I want to publish it.
The Publish button isn't enabled. In order to be able to publish the template, I would need to introduce another change.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
