### PR TITLE
dotCMS/core#21701 Change page title when new content is created

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
@@ -330,6 +330,25 @@ describe('DotContentletWrapperComponent', () => {
                     expect(component.header).toBe('Blog');
                     expect(titleService.setTitle).toHaveBeenCalledWith('test -  dotCMS platform');
                 });
+
+                it('should set Page title when a new contentlet will be created', () => {
+                    const params = {
+                        detail: {
+                            name: 'edit-contentlet-loaded',
+                            data: {
+                                contentType: 'Blog',
+                                pageTitle: ''
+                            }
+                        }
+                    };
+                    spyOn(titleService, 'getTitle').and.returnValue(' - dotCMS platform');
+                    dotIframeDialog.triggerEventHandler('custom', params);
+
+                    expect(component.header).toBe('Blog');
+                    expect(titleService.setTitle).toHaveBeenCalledWith(
+                        'New Blog -  dotCMS platform'
+                    );
+                });
             });
         });
     });

--- a/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.ts
@@ -89,7 +89,7 @@ export class DotContentletWrapperComponent {
                         `${
                             e.detail.data.pageTitle
                                 ? e.detail.data.pageTitle + ' - '
-                                : this.titleService.getTitle()
+                                : `${this.dotMessageService.get('New')} ${this.header} - `
                         } ${this.titleService.getTitle().split(' - ')[1]}`
                     );
                 }


### PR DESCRIPTION
We're missing this condition
- if it is a new contentlet, then we change it to new contentType.name the content edition dialog show the CT but the page title does not

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
