### PR TITLE
dotCMS/core#21884 Add margin between contentlet and image blocks 

### DIFF
--- a/libs/block-editor/src/lib/extensions/blocks/contentlet-block/contentlet-block.component.scss
+++ b/libs/block-editor/src/lib/extensions/blocks/contentlet-block/contentlet-block.component.scss
@@ -5,6 +5,7 @@ dotcms-contentlet-block {
     height: 100%;
     width: 100%;
     box-sizing: border-box;
+    margin-bottom: $spacing-1;
 }
 
 .p-card {

--- a/libs/block-editor/src/lib/extensions/blocks/contentlet-block/contentlet-block.component.scss
+++ b/libs/block-editor/src/lib/extensions/blocks/contentlet-block/contentlet-block.component.scss
@@ -5,7 +5,7 @@ dotcms-contentlet-block {
     height: 100%;
     width: 100%;
     box-sizing: border-box;
-    margin-bottom: $spacing-1;
+    margin-bottom: $spacing-3;
 }
 
 .p-card {

--- a/libs/block-editor/src/lib/extensions/blocks/image-block/image-block.component.scss
+++ b/libs/block-editor/src/lib/extensions/blocks/image-block/image-block.component.scss
@@ -1,5 +1,8 @@
+@use "libs/dot-primeng-theme-styles/src/scss/variables" as *;
+
 :host {
     display: block;
+    margin-bottom: $spacing-1;
 
     img {
         max-width: 100%;

--- a/libs/block-editor/src/lib/extensions/blocks/image-block/image-block.component.scss
+++ b/libs/block-editor/src/lib/extensions/blocks/image-block/image-block.component.scss
@@ -2,7 +2,7 @@
 
 :host {
     display: block;
-    margin-bottom: $spacing-1;
+    margin-bottom: $spacing-3;
 
     img {
         max-width: 100%;


### PR DESCRIPTION
Result: 

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/31667212/159721502-d2576a77-034b-4670-8790-b174b58403d1.png">
