### PR TITLE
dotCMS/core#21885 Using binary = true to avoid multiple selection in …

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.html
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.html
@@ -17,7 +17,9 @@
     <div class="template-listing__header-options">
         <div>
             <p-checkbox
+                data-testid="archiveCheckbox"
                 [label]="'Show-Archived' | dm"
+                [binary]="true"
                 (onChange)="handleArchivedFilter($event.checked)"
             ></p-checkbox>
             <button

--- a/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
@@ -344,6 +344,14 @@ describe('DotTemplateListComponent', () => {
         dotSiteBrowserService = TestBed.inject(DotSiteBrowserService);
     });
 
+    it('should reload portlet only when the site change', () => {
+        const checkbox = fixture.debugElement.query(By.css('[data-testId="archiveCheckbox"]')).componentInstance;
+
+        fixture.detectChanges();
+
+        expect(checkbox.binary).toBeTruthy();
+    });
+    
     describe('with data', () => {
         beforeEach(fakeAsync(() => {
             spyOn<any>(coreWebService, 'requestView').and.returnValue(


### PR DESCRIPTION
### Proposed Changes
Using binary = true to avoid multiple selection