### PR TITLE
dotCMS/core#21979 Content type contextual menu cutting off

### DIFF
--- a/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.scss
+++ b/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.scss
@@ -14,6 +14,10 @@
     ::ng-deep {
         .p-datatable {
             position: initial;
+
+            &.p-datatable-responsive-scroll > .p-datatable-wrapper {
+                overflow-x: visible;
+            }
         }
 
         .p-datatable,


### PR DESCRIPTION
### Proposed Changes
* Avoid table scroll. 
* https://github.com/dotCMS/core/issues/21979
