### PR TITLE
Issue 19562 hide duplicated error message when key is changed

### DIFF
--- a/libs/dotcms-webcomponents/src/components.d.ts
+++ b/libs/dotcms-webcomponents/src/components.d.ts
@@ -2403,6 +2403,10 @@ declare namespace LocalJSX {
          */
         "onAdd"?: (event: CustomEvent<DotKeyValueField>) => void;
         /**
+          * Emit when key is changed
+         */
+        "onKeyChanged"?: (event: CustomEvent<string>) => void;
+        /**
           * Emit when any of the input is blur
          */
         "onLostFocus"?: (event: CustomEvent<FocusEvent>) => void;

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/components/key-value-form/key-value-form.e2e.ts
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/components/key-value-form/key-value-form.e2e.ts
@@ -200,6 +200,18 @@ describe('key-value-form', () => {
             });
         });
 
+        describe('keyChanged', () => {
+            beforeEach(async () => {
+                spyAddEvent = await page.spyOnEvent('keyChanged');
+            });
+
+            it('should emit on form valid and submit', async () => {
+                await typeKey();
+
+                expect(spyAddEvent).toHaveReceivedEventDetail('key');
+            });
+        });
+
         xdescribe('lostFocus', () => {
             it('should emit when input gets blur', async () => {});
         });

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/components/key-value-form/key-value-form.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/components/key-value-form/key-value-form.tsx
@@ -61,6 +61,10 @@ export class DotKeyValueComponent {
     @Event()
     add: EventEmitter<DotKeyValueField>;
 
+    /** Emit when key is changed */
+    @Event()
+    keyChanged: EventEmitter<string>;
+
     /** Emit when any of the input is blur */
     @Event()
     lostFocus: EventEmitter<FocusEvent>;
@@ -235,6 +239,11 @@ export class DotKeyValueComponent {
         event.stopImmediatePropagation();
 
         const target = event.target as HTMLInputElement;
+
+        if (target.name === 'key') {
+            this.keyChanged.emit(target.value.toString());
+        }
+
         this.inputs = {
             ...this.inputs,
             [target.name]: target.value.toString()

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/components/key-value-form/readme.md
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/components/key-value-form/readme.md
@@ -21,10 +21,11 @@
 
 ## Events
 
-| Event       | Description                          | Type                            |
-| ----------- | ------------------------------------ | ------------------------------- |
-| `add`       | Emit the added value, key/value pair | `CustomEvent<DotKeyValueField>` |
-| `lostFocus` | Emit when any of the input is blur   | `CustomEvent<FocusEvent>`       |
+| Event        | Description                          | Type                            |
+| ------------ | ------------------------------------ | ------------------------------- |
+| `add`        | Emit the added value, key/value pair | `CustomEvent<DotKeyValueField>` |
+| `keyChanged` | Emit when key is changed             | `CustomEvent<string>`           |
+| `lostFocus`  | Emit when any of the input is blur   | `CustomEvent<FocusEvent>`       |
 
 
 ## Dependencies

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.e2e.ts
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.e2e.ts
@@ -444,6 +444,18 @@ describe('dot-key-value', () => {
                 });
             });
         });
+
+        describe('errorExistingKey', () => {
+            it('shoult reset value on keyChanged', async () => {
+                const form = await getForm();
+                form.triggerEvent('keyChanged', {
+                    detail: 'a'
+                });
+                await page.waitForChanges();
+                const error = await dotTestUtil.getErrorMessage(page);
+                expect(error).toBeNull();
+            });
+        });
     });
 
     describe('@Methods', () => {

--- a/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.tsx
+++ b/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.tsx
@@ -145,8 +145,8 @@ export class DotKeyValueComponent {
     })
     whiteList: string;
 
+    @State()
     errorExistingKey: boolean;
-
     @State()
     status: DotFieldStatus;
     @State()
@@ -224,6 +224,14 @@ export class DotKeyValueComponent {
         if ((this.uniqueKeys && !this.errorExistingKey) || !this.uniqueKeys) {
             this.items = [...this.items, detail];
             this.emitChanges();
+        }
+    }
+
+    @Listen('keyChanged')
+    keyChangedHandler(): void {
+        // Reset errorExistingKey value when KEY is changed
+        if (this.errorExistingKey) {
+            this.errorExistingKey = false;
         }
     }
 


### PR DESCRIPTION
we just need to hide the "key already exist" message every time you change the dropDown value

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
