### PR TITLE
dotCMS/core#21915 Add inline edit to content type name and Icon

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
@@ -42,7 +42,7 @@ export class ContentTypeFieldsPropertiesFormComponent implements OnChanges, OnIn
     constructor(private fb: FormBuilder, private fieldPropertyService: FieldPropertyService) {}
 
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes.formFieldData.currentValue && this.formFieldData) {
+        if (changes.formFieldData?.currentValue && this.formFieldData) {
             this.destroy();
 
             setTimeout(this.init.bind(this), 0);

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
@@ -2,7 +2,24 @@
     <div class="main-toolbar-left">
         <div class="content-type__title">
             <header>
-                <h4>{{ contentType.name }}</h4>
+                <dot-icon name="{{ contentType.icon }}"></dot-icon>
+                <p-inplace #contentTypeInlineEdit (onActivate)="editInlineActivate($event)">
+                    <ng-template pTemplate="display">
+                        <h4>{{ contentType.name }}</h4>
+                    </ng-template>
+                    <ng-template pTemplate="content">
+                        <input
+                            [style.width.px]="contentTypeNameInputSize"
+                            #contentTypeNameInput
+                            type="text"
+                            [value]="contentType.name"
+                            (keydown.enter)="fireChangeName()"
+                            (keydown.escape)="contentTypeInlineEdit.deactivate()"
+                            pInputText
+                            dotAutofocus
+                        />
+                    </ng-template>
+                </p-inplace>
                 <dot-api-link href="api/v1/contenttype/id/{{ contentType.id }}"></dot-api-link>
             </header>
         </div>
@@ -10,11 +27,17 @@
         <div class="content-type__info">
             {{ 'contenttypes.content.variable' | dm }}:
             <dot-copy-link
+                data-testId="copyVariableName"
                 [copy]="contentType.variable"
                 [label]="contentType.variable"
             ></dot-copy-link>
             <span class="content-type__dot-separator">•</span>
-            {{ 'contenttypes.form.identifier' | dm }}: {{ contentType.id }}
+            {{ 'contenttypes.form.identifier' | dm }}:
+            <dot-copy-link
+                data-testId="copyIdentifier"
+                [copy]="contentType.id"
+                [label]="contentType.id"
+            ></dot-copy-link>
         </div>
     </div>
     <div class="main-toolbar-right">

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
@@ -3,23 +3,27 @@
         <div class="content-type__title">
             <header>
                 <dot-icon name="{{ contentType.icon }}"></dot-icon>
-                <p-inplace #contentTypeInlineEdit (onActivate)="editInlineActivate($event)">
-                    <ng-template pTemplate="display">
-                        <h4>{{ contentType.name }}</h4>
-                    </ng-template>
-                    <ng-template pTemplate="content">
-                        <input
-                            [style.width.px]="contentTypeNameInputSize"
-                            #contentTypeNameInput
-                            type="text"
-                            [value]="contentType.name"
-                            (keydown.enter)="fireChangeName()"
-                            (keydown.escape)="contentTypeInlineEdit.deactivate()"
-                            pInputText
-                            dotAutofocus
-                        />
-                    </ng-template>
-                </p-inplace>
+                <ng-template #inlineEditDisplayTemplate>
+                    <h4 (click)="editInlineActivate($event)">{{ contentType.name }}</h4>
+                </ng-template>
+                <ng-template #inlineEditContentTemplate>
+                    <input
+                        [style.width.px]="contentTypeNameInputSize"
+                        #contentTypeNameInput
+                        type="text"
+                        [value]="contentType.name"
+                        (keydown.enter)="fireChangeName()"
+                        (keydown.escape)="dotEditInline.hideContent()"
+                        pInputText
+                        dotAutofocus
+                    />
+                </ng-template>
+                <dot-inline-edit
+                    #dotEditInline
+                    [inlineEditDisplayTemplate]="inlineEditDisplayTemplate"
+                    [inlineEditContentTemplate]="inlineEditContentTemplate"
+                >
+                </dot-inline-edit>
                 <dot-api-link href="api/v1/contenttype/id/{{ contentType.id }}"></dot-api-link>
             </header>
         </div>

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
@@ -102,6 +102,33 @@ $top-height: ($toolbar-height + $tabview-nav-height + $dot-secondary-toolbar-mai
         header {
             display: flex;
             align-items: center;
+
+            dot-icon {
+                align-items: center;
+                margin-right: $spacing-2;
+            }
+
+            ::ng-deep {
+                p-inplace {
+                    h4,
+                    input {
+                        min-width: 50px;
+                    }
+
+                    .p-inplace-display {
+                        display: flex;
+                        padding: 0;
+                    }
+
+                    .p-inplace-content input {
+                        height: 36px;
+                    }
+
+                    button {
+                        margin-left: $spacing-2;
+                    }
+                }
+            }
         }
 
         h4 {

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
@@ -27,6 +27,7 @@ import { TabViewModule } from 'primeng/tabview';
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { MenuItem } from 'primeng/api';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
+import { InplaceModule } from 'primeng/inplace';
 
 @Component({
     selector: 'dot-content-types-fields-list',
@@ -78,6 +79,7 @@ class FieldDragDropServiceMock {
 
 const fakeContentType: DotCMSContentType = {
     ...dotcmsContentTypeBasicMock,
+    icon: 'testIcon',
     id: '1234567890',
     name: 'name',
     variable: 'helloVariable',
@@ -121,6 +123,7 @@ describe('ContentTypesLayoutComponent', () => {
                 DotCopyLinkModule,
                 DotPipesModule,
                 SplitButtonModule,
+                InplaceModule,
                 HttpClientTestingModule,
                 DotPortletBoxModule
             ],
@@ -155,9 +158,8 @@ describe('ContentTypesLayoutComponent', () => {
     });
 
     it('should set the field and row bag options', () => {
-        const fieldDragDropService: FieldDragDropService = fixture.debugElement.injector.get(
-            FieldDragDropService
-        );
+        const fieldDragDropService: FieldDragDropService =
+            fixture.debugElement.injector.get(FieldDragDropService);
         fixture.componentInstance.contentType = fakeContentType;
         spyOn(fieldDragDropService, 'setBagOptions');
         fixture.detectChanges();
@@ -214,9 +216,36 @@ describe('ContentTypesLayoutComponent', () => {
         });
 
         it('should have elements in the correct place', () => {
+            expect(
+                de.query(By.css('.main-toolbar-left header dot-icon')).componentInstance.name
+            ).toBe(fakeContentType.icon);
+            expect(de.query(By.css('.main-toolbar-left header p-inplace'))).toBeDefined();
+            expect(
+                de.query(By.css('.main-toolbar-left header p-inplace h4')).nativeElement.innerHTML
+            ).toBe(fakeContentType.name);
             expect(de.query(By.css('.main-toolbar-left .content-type__title'))).toBeDefined();
             expect(de.query(By.css('.main-toolbar-left .content-type__info'))).toBeDefined();
             expect(de.query(By.css('.main-toolbar-right #form-edit-button'))).toBeDefined();
+        });
+
+        it('should set and emit change name of Content Type', () => {
+            de.query(By.css('.main-toolbar-left header p-inplace h4')).nativeElement.click();
+            fixture.detectChanges();
+
+            spyOn(de.componentInstance.changeContentTypeName, 'emit');
+
+            expect(de.query(By.css('.main-toolbar-left header p-inplace input'))).toBeDefined();
+            de.query(By.css('.main-toolbar-left header p-inplace input')).nativeElement.value =
+                'changedName';
+            de.query(By.css('.main-toolbar-left header p-inplace input')).triggerEventHandler(
+                'keydown.enter',
+                {
+                    stopPropagation: jasmine.createSpy('stopPropagation')
+                }
+            );
+            expect(de.componentInstance.changeContentTypeName.emit).toHaveBeenCalledWith(
+                'changedName'
+            );
         });
 
         it('should have api link component', () => {
@@ -226,8 +255,14 @@ describe('ContentTypesLayoutComponent', () => {
         });
 
         it('should have copy variable link', () => {
-            expect(de.query(By.css('dot-copy-link')).componentInstance.copy).toBe(
-                'helloVariable'
+            expect(
+                de.query(By.css('[data-testId="copyVariableName"]')).componentInstance.copy
+            ).toBe('helloVariable');
+        });
+
+        it('should have copy identifier link', () => {
+            expect(de.query(By.css('[data-testId="copyIdentifier"]')).componentInstance.copy).toBe(
+                '1234567890'
             );
         });
 

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
@@ -27,7 +27,7 @@ import { TabViewModule } from 'primeng/tabview';
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { MenuItem } from 'primeng/api';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
-import { InplaceModule } from 'primeng/inplace';
+import { DotInlineEditModule } from '@components/_common/dot-inline-edit/dot-inline-edit.module';
 
 @Component({
     selector: 'dot-content-types-fields-list',
@@ -123,7 +123,7 @@ describe('ContentTypesLayoutComponent', () => {
                 DotCopyLinkModule,
                 DotPipesModule,
                 SplitButtonModule,
-                InplaceModule,
+                DotInlineEditModule,
                 HttpClientTestingModule,
                 DotPortletBoxModule
             ],
@@ -219,7 +219,7 @@ describe('ContentTypesLayoutComponent', () => {
             expect(
                 de.query(By.css('.main-toolbar-left header dot-icon')).componentInstance.name
             ).toBe(fakeContentType.icon);
-            expect(de.query(By.css('.main-toolbar-left header p-inplace'))).toBeDefined();
+            expect(de.query(By.css('.main-toolbar-left header dot-inline-edit'))).toBeDefined();
             expect(
                 de.query(By.css('.main-toolbar-left header p-inplace h4')).nativeElement.innerHTML
             ).toBe(fakeContentType.name);
@@ -232,7 +232,12 @@ describe('ContentTypesLayoutComponent', () => {
             de.query(By.css('.main-toolbar-left header p-inplace h4')).nativeElement.click();
             fixture.detectChanges();
 
+            const dotInlineEditComp = de.query(
+                By.css('.main-toolbar-left header dot-inline-edit')
+            ).componentInstance;
+
             spyOn(de.componentInstance.changeContentTypeName, 'emit');
+            spyOn(dotInlineEditComp, 'hideContent');
 
             expect(de.query(By.css('.main-toolbar-left header p-inplace input'))).toBeDefined();
             de.query(By.css('.main-toolbar-left header p-inplace input')).nativeElement.value =
@@ -246,6 +251,7 @@ describe('ContentTypesLayoutComponent', () => {
             expect(de.componentInstance.changeContentTypeName.emit).toHaveBeenCalledWith(
                 'changedName'
             );
+            expect(dotInlineEditComp.hideContent).toHaveBeenCalledTimes(1);
         });
 
         it('should have api link component', () => {

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
@@ -17,7 +17,7 @@ import { DotEventsService } from '@services/dot-events/dot-events.service';
 import { DotCMSContentType } from '@dotcms/dotcms-models';
 import { DotCurrentUserService } from '@services/dot-current-user/dot-current-user.service';
 import { Observable } from 'rxjs';
-import { Inplace } from 'primeng/inplace';
+import { DotInlineEditComponent } from '@components/_common/dot-inline-edit/dot-inline-edit.component';
 
 @Component({
     selector: 'dot-content-type-layout',
@@ -29,7 +29,7 @@ export class ContentTypesLayoutComponent implements OnChanges, OnInit {
     @Output() openEditDialog: EventEmitter<unknown> = new EventEmitter();
     @Output() changeContentTypeName: EventEmitter<string> = new EventEmitter();
     @ViewChild('contentTypeNameInput') contentTypeNameInput: ElementRef;
-    @ViewChild('contentTypeInlineEdit') contentTypeInlineEdit: Inplace;
+    @ViewChild('dotEditInline') dotEditInline: DotInlineEditComponent;
 
     permissionURL: string;
     pushHistoryURL: string;
@@ -72,7 +72,6 @@ export class ContentTypesLayoutComponent implements OnChanges, OnInit {
      *
      * @memberof ContentTypesLayoutComponent
      */
-
     fireAddRowEvent(): void {
         this.dotEventsService.notify('add-row');
     }
@@ -86,9 +85,14 @@ export class ContentTypesLayoutComponent implements OnChanges, OnInit {
         const contentTypeName = this.contentTypeNameInput.nativeElement.value.trim();
         this.changeContentTypeName.emit(contentTypeName);
         this.contentType.name = contentTypeName;
-        this.contentTypeInlineEdit.deactivate();
+        this.dotEditInline.hideContent();
     }
 
+    /**
+     * Sets the size of the H4 display to set it in the content textbox to eliminate UI jumps
+     *
+     * @memberof ContentTypesLayoutComponent
+     */
     editInlineActivate(event): void {
         this.contentTypeNameInputSize = event.target.offsetWidth;
     }

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
@@ -1,4 +1,13 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import {
+    Component,
+    ElementRef,
+    EventEmitter,
+    Input,
+    OnChanges,
+    OnInit,
+    Output,
+    ViewChild
+} from '@angular/core';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
 import { DotMenuService } from '@services/dot-menu.service';
 import { FieldDragDropService } from '../fields/service';
@@ -8,6 +17,7 @@ import { DotEventsService } from '@services/dot-events/dot-events.service';
 import { DotCMSContentType } from '@dotcms/dotcms-models';
 import { DotCurrentUserService } from '@services/dot-current-user/dot-current-user.service';
 import { Observable } from 'rxjs';
+import { Inplace } from 'primeng/inplace';
 
 @Component({
     selector: 'dot-content-type-layout',
@@ -17,9 +27,14 @@ import { Observable } from 'rxjs';
 export class ContentTypesLayoutComponent implements OnChanges, OnInit {
     @Input() contentType: DotCMSContentType;
     @Output() openEditDialog: EventEmitter<unknown> = new EventEmitter();
+    @Output() changeContentTypeName: EventEmitter<string> = new EventEmitter();
+    @ViewChild('contentTypeNameInput') contentTypeNameInput: ElementRef;
+    @ViewChild('contentTypeInlineEdit') contentTypeInlineEdit: Inplace;
+
     permissionURL: string;
     pushHistoryURL: string;
     relationshipURL: string;
+    contentTypeNameInputSize: string;
     showPermissionsTab: Observable<boolean>;
 
     actions: MenuItem[];
@@ -52,8 +67,30 @@ export class ContentTypesLayoutComponent implements OnChanges, OnInit {
         }
     }
 
+    /**
+     * Emits add-row event to add new row
+     *
+     * @memberof ContentTypesLayoutComponent
+     */
+
     fireAddRowEvent(): void {
         this.dotEventsService.notify('add-row');
+    }
+
+    /**
+     * Emits new name to parent component and close Edit Inline mode
+     *
+     * @memberof ContentTypesLayoutComponent
+     */
+    fireChangeName(): void {
+        const contentTypeName = this.contentTypeNameInput.nativeElement.value.trim();
+        this.changeContentTypeName.emit(contentTypeName);
+        this.contentType.name = contentTypeName;
+        this.contentTypeInlineEdit.deactivate();
+    }
+
+    editInlineActivate(event): void {
+        this.contentTypeNameInputSize = event.target.offsetWidth;
     }
 
     private loadActions(): void {

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
@@ -1,6 +1,7 @@
 <dot-content-type-layout
     [contentType]="data"
     (openEditDialog)="startFormDialog()"
+    (changeContentTypeName)="editContentTypeName($event)"
     *ngIf="isEditMode()"
 >
     <dot-content-type-fields-drop-zone

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -68,6 +68,7 @@ class TestContentTypeFieldsDropZoneComponent {
 class TestContentTypeLayoutComponent {
     @Input() contentType: DotCMSContentType;
     @Output() openEditDialog: EventEmitter<any> = new EventEmitter();
+    @Output() changeContentTypeName: EventEmitter<string> = new EventEmitter();
 }
 
 @Component({
@@ -750,6 +751,32 @@ describe('DotContentTypesEditComponent', () => {
             contentTypeFieldsDropZone.componentInstance.removeFields.emit(fieldToRemove);
 
             expect(dotHttpErrorManagerService.handle).toHaveBeenCalledTimes(1);
+        });
+
+        it('should update Content Type name on dot-content-type-layout event', () => {
+            const responseContentType = Object.assign({}, fakeContentType, {
+                name: 'CT changed'
+            });
+
+            spyOn(crudService, 'putData').and.returnValue(of(responseContentType));
+
+            const contentTypeLayout = de.query(By.css('dot-content-type-layout'));
+            contentTypeLayout.triggerEventHandler('changeContentTypeName', 'CT changed');
+
+            const replacedWorkflowsPropContentType = {
+                ...responseContentType
+            };
+
+            replacedWorkflowsPropContentType['workflow'] = fakeContentType.workflows.map(
+                (workflow) => workflow.id
+            );
+            delete replacedWorkflowsPropContentType.workflows;
+
+            expect(crudService.putData).toHaveBeenCalledWith(
+                'v1/contenttype/id/1234567890',
+                replacedWorkflowsPropContentType
+            );
+            expect(comp.data).toEqual(responseContentType, 'set data with response');
         });
 
         describe('update', () => {

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
@@ -125,6 +125,17 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
     }
 
     /**
+     * Set updated name on Content Type and send a request to save it
+     * @param {string} name
+     *
+     * @memberof DotContentTypesEditComponent
+     */
+    editContentTypeName(name: string): void {
+        const updatedContentType = { ...this.data, name };
+        this.updateContentType(updatedContentType);
+    }
+
+    /**
      * Set the icon, labels and placeholder in the template
      * @memberof DotContentTypesEditComponent
      */

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
@@ -69,6 +69,7 @@ import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { RadioButtonModule } from 'primeng/radiobutton';
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { TabViewModule } from 'primeng/tabview';
+import { InplaceModule } from 'primeng/inplace';
 import { DotRelationshipTreeModule } from '@components/dot-relationship-tree/dot-relationship-tree.module';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
 import { DotMdIconSelectorModule } from '@dotcms/app/view/components/_common/dot-md-icon-selector/dot-md-icon-selector.module';
@@ -129,6 +130,7 @@ import { DotMdIconSelectorModule } from '@dotcms/app/view/components/_common/dot
         DropdownModule,
         FormsModule,
         IFrameModule,
+        InplaceModule,
         InputTextModule,
         MultiSelectModule,
         OverlayPanelModule,

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
@@ -69,10 +69,10 @@ import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { RadioButtonModule } from 'primeng/radiobutton';
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { TabViewModule } from 'primeng/tabview';
-import { InplaceModule } from 'primeng/inplace';
 import { DotRelationshipTreeModule } from '@components/dot-relationship-tree/dot-relationship-tree.module';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
 import { DotMdIconSelectorModule } from '@dotcms/app/view/components/_common/dot-md-icon-selector/dot-md-icon-selector.module';
+import { DotInlineEditModule } from '@components/_common/dot-inline-edit/dot-inline-edit.module';
 
 @NgModule({
     declarations: [
@@ -130,7 +130,7 @@ import { DotMdIconSelectorModule } from '@dotcms/app/view/components/_common/dot
         DropdownModule,
         FormsModule,
         IFrameModule,
-        InplaceModule,
+        DotInlineEditModule,
         InputTextModule,
         MultiSelectModule,
         OverlayPanelModule,

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.component.html
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.component.html
@@ -1,0 +1,8 @@
+<p-inplace #contentTypeInlineEdit>
+    <ng-template pTemplate="display">
+        <ng-container [ngTemplateOutlet]="inlineEditDisplayTemplate"></ng-container>
+    </ng-template>
+    <ng-template pTemplate="content">
+        <ng-container [ngTemplateOutlet]="inlineEditContentTemplate"></ng-container>
+    </ng-template>
+</p-inplace>

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.component.spec.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { Component, DebugElement, Input, TemplateRef } from '@angular/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { By } from '@angular/platform-browser';
+import { SharedModule } from 'primeng/api';
+import { InplaceModule } from 'primeng/inplace';
+import { DotInlineEditComponent } from './dot-inline-edit.component';
+
+@Component({
+    selector: 'dot-host-component',
+    template: `
+        <ng-template #inlineEditDisplayTemplate>
+            <h4>Display Text</h4>
+        </ng-template>
+        <ng-template #inlineEditContentTemplate>
+            <input />
+        </ng-template>
+        <dot-inline-edit
+            #dotEditInline
+            [inlineEditDisplayTemplate]="inlineEditDisplayTemplate"
+            [inlineEditContentTemplate]="inlineEditContentTemplate"
+        ></dot-inline-edit>
+    `
+})
+class HostTestComponent {
+    @Input() inlineEditDisplayTemplate?: TemplateRef<unknown>;
+    @Input() inlineEditContentTemplate?: TemplateRef<unknown>;
+}
+
+fdescribe('DotInlineEditComponent', () => {
+    let hostFixture: ComponentFixture<HostTestComponent>;
+    let comp: DotInlineEditComponent;
+    let de: DebugElement;
+
+    beforeEach(
+        waitForAsync(() => {
+            TestBed.configureTestingModule({
+                declarations: [DotInlineEditComponent, HostTestComponent],
+                imports: [CommonModule, InplaceModule, SharedModule, HttpClientTestingModule],
+                providers: []
+            }).compileComponents();
+
+            hostFixture = TestBed.createComponent(HostTestComponent);
+            de = hostFixture.debugElement;
+            comp = hostFixture.debugElement.query(By.css('dot-inline-edit')).componentInstance;
+            hostFixture.detectChanges();
+        })
+    );
+
+    it(`should have display section and component variables defined`, () => {
+        expect(comp.inlineEditDisplayTemplate).toBeDefined();
+        expect(comp.inlineEditContentTemplate).toBeDefined();
+        expect(de.query(By.css('p-inplace h4')).nativeElement.innerHTML).toBe('Display Text');
+    });
+
+    it('should set and emit change name of Content Type', () => {
+        de.query(By.css('p-inplace h4')).nativeElement.click();
+        hostFixture.detectChanges();
+
+        expect(de.query(By.css('p-inplace input')).nativeElement).toBeDefined();
+    });
+
+    it('should hide Content section when "hideContent" method called', () => {
+        de.query(By.css('p-inplace h4')).nativeElement.click();
+        hostFixture.detectChanges();
+
+        comp.hideContent();
+        hostFixture.detectChanges();
+
+        expect(de.query(By.css('p-inplace input'))).toBeNull();
+        expect(de.query(By.css('p-inplace h4')).nativeElement.innerHTML).toBe('Display Text');
+    });
+});

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.component.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { Inplace } from 'primeng/inplace';
+
+@Component({
+    selector: 'dot-inline-edit',
+    templateUrl: './dot-inline-edit.component.html'
+})
+export class DotInlineEditComponent {
+    @Input()
+    inlineEditDisplayTemplate: TemplateRef<unknown>;
+    @Input()
+    inlineEditContentTemplate: TemplateRef<unknown>;
+
+    @ViewChild('contentTypeInlineEdit') contentTypeInlineEdit: Inplace;
+
+    /**
+     * Manually hides the content/edit section of p-inplace
+     *
+     * @memberof DotInlineEditComponent
+     */
+    hideContent(): void {
+        this.contentTypeInlineEdit.deactivate();
+    }
+}

--- a/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.module.ts
+++ b/apps/dotcms-ui/src/app/view/components/_common/dot-inline-edit/dot-inline-edit.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { DotInlineEditComponent } from './dot-inline-edit.component';
+import { InplaceModule } from 'primeng/inplace';
+import { SharedModule } from 'primeng/api';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+    imports: [CommonModule, InplaceModule, SharedModule],
+    declarations: [DotInlineEditComponent],
+    exports: [DotInlineEditComponent],
+    providers: []
+})
+export class DotInlineEditModule {}


### PR DESCRIPTION
### Proposed Changes
On the Edit Content Type Screen:

- It would be nice to show the icon
- You should be able to click and quickly edit the content type name and icon
- The identifier needs to have COPY functionality

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
