### PR TITLE
dotCMS/core#21307 fix personas-portlet-not-showing-require-license

### DIFF
--- a/apps/dotcms-ui/src/app/api/services/dot-license/dot-license.service.ts
+++ b/apps/dotcms-ui/src/app/api/services/dot-license/dot-license.service.ts
@@ -27,6 +27,11 @@ const enterprisePorlets: DotUnlicensedPortletData[] = [
         url: '/c/site-search'
     },
     {
+        icon: 'person',
+        titleKey: 'com.dotcms.repackage.javax.portlet.title.personas',
+        url: '/c/c_Personas'
+    },
+    {
         icon: 'update',
         titleKey: 'com.dotcms.repackage.javax.portlet.title.time-machine',
         url: '/c/time-machine'


### PR DESCRIPTION
### Proposed Changes
* We are unable to show the required license message when you are using the community edition and you try to access to the personas portlet, we are showing an error in the log and display a blank page.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
