### PR TITLE
dotCMS/core#22094 fix noHtml-regex-invalidates-period-on-contentType title

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.html
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.html
@@ -7,7 +7,7 @@
         <p-dropdown
             appendTo="body"
             [style]="{ width: '125px' }"
-            [options]="regexCheckTempletes"
+            [options]="regexCheckTemplates"
             (onChange)="templateSelect($event)"
             [formControlName]="property.name"
         >

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.spec.ts
@@ -71,7 +71,7 @@ describe('RegexCheckPropertyComponent', () => {
 
         const pDropDown: DebugElement = fixture.debugElement.query(By.css('p-dropdown'));
         expect(pDropDown).not.toBeNull();
-        expect(comp.regexCheckTempletes).toBe(pDropDown.componentInstance.options);
+        expect(comp.regexCheckTemplates).toBe(pDropDown.componentInstance.options);
     });
 
     it('should change the input value', () => {

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/regex-check-property/regex-check-property.component.ts
@@ -13,7 +13,7 @@ export interface RegexTemplate {
     styleUrls: ['./regex-check-property.component.scss']
 })
 export class RegexCheckPropertyComponent implements OnInit {
-    regexCheckTempletes: RegexTemplate[] = [];
+    regexCheckTemplates: RegexTemplate[] = [];
 
     property: FieldProperty;
     group: FormGroup;
@@ -21,7 +21,7 @@ export class RegexCheckPropertyComponent implements OnInit {
     constructor(private dotMessageService: DotMessageService) {}
 
     ngOnInit() {
-        this.regexCheckTempletes = [
+        this.regexCheckTemplates = [
             {
                 label: this.dotMessageService.get(
                     'contenttypes.field.properties.validation_regex.values.select'
@@ -76,7 +76,7 @@ export class RegexCheckPropertyComponent implements OnInit {
                 label: this.dotMessageService.get(
                     'contenttypes.field.properties.validation_regex.values.no_html'
                 ),
-                value: '[^(<[.\n]+>)]*'
+                value: '^[^<><|>]+$'
             }
         ];
     }


### PR DESCRIPTION
When you add the "No HTML" validation RegEx to a field in a content type then try to save a contentlet with a period in that field (.) the RegEx is triggered and the period is treated like HTML.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
