### PR TITLE
dotCMS/core#21818 Reload contentlet on edit using #editContentlet macro

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -664,7 +664,7 @@ export class DotEditContentHtmlService {
                     // because: https://github.com/dotCMS/core/issues/21818
                     setTimeout(() => {
                         this.renderEditedContentlet(this.currentContentlet);
-                    }, 3000);
+                    }, 1800);
                 }
             },
             inlineEdit: (contentlet: DotInlineEditContent) => {

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -655,13 +655,17 @@ export class DotEditContentHtmlService {
         const contentletEventsMap = {
             // When an user create or edit a contentlet from the jsp
             save: (contentlet: DotPageContent) => {
+                console.log('handlerContentletEvents');
                 if (this.currentAction === DotContentletAction.ADD) {
                     this.renderAddedContentlet(contentlet);
                 } else {
                     if (this.updateContentletInode) {
                         this.currentContentlet.inode = contentlet.inode;
                     }
-                    this.renderEditedContentlet(this.currentContentlet);
+                    // because: https://github.com/dotCMS/core/issues/21818
+                    setTimeout(() => {
+                        this.renderEditedContentlet(this.currentContentlet);
+                    }, 3000);
                 }
             },
             inlineEdit: (contentlet: DotInlineEditContent) => {

--- a/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -655,7 +655,6 @@ export class DotEditContentHtmlService {
         const contentletEventsMap = {
             // When an user create or edit a contentlet from the jsp
             save: (contentlet: DotPageContent) => {
-                console.log('handlerContentletEvents');
                 if (this.currentAction === DotContentletAction.ADD) {
                     this.renderAddedContentlet(contentlet);
                 } else {


### PR DESCRIPTION
### Proposed Changes
* Delay the update of the page, to wait for content re-index when updating with ContentletAjax.saveContent