### PR TITLE
#dotCMS/core#22532 include in 22.03.6

### DIFF
--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.spec.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.spec.ts
@@ -28,7 +28,8 @@ import { DotPipesModule } from '@pipes/dot-pipes.module';
 const mockDFormFieldData = {
     ...dotcmsContentTypeFieldBasicMock,
     clazz: 'field.class',
-    name: 'fieldName'
+    name: 'fieldName',
+    id: '123'
 };
 
 @Component({
@@ -162,7 +163,8 @@ xdescribe('ContentTypeFieldsPropertiesFormComponent', () => {
             spyOn(mockFieldPropertyService, 'getProperties').and.returnValue([
                 'property1',
                 'property2',
-                'property3'
+                'property3',
+                'id'
             ]);
         });
 
@@ -172,6 +174,7 @@ xdescribe('ContentTypeFieldsPropertiesFormComponent', () => {
             expect(mockFieldPropertyService.getProperties).toHaveBeenCalledWith('field.class');
             expect(comp.form.get('clazz').value).toBe('field.class');
 
+            expect(comp.form.get('id').value).toBe('123');
             expect(comp.form.get('property1').value).toBe('');
             expect(comp.form.get('property2').value).toBe(true);
             expect(comp.form.get('property3')).toBeNull();

--- a/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
+++ b/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
@@ -118,6 +118,7 @@ export class ContentTypeFieldsPropertiesFormComponent implements OnChanges, OnIn
                 });
 
             formFields['clazz'] = this.formFieldData.clazz;
+            formFields['id'] = this.formFieldData.id;
         }
 
         this.form = this.fb.group(formFields);


### PR DESCRIPTION
### Proposed Changes
* Added missing field id to form value containing the data of the field to be updated.
* With this fix, the handler for the save button of the edit field dialog will call the appropriate API endpoint to update fields (`v3/contenttype/${contentTypeId}/fields/${field.id}`) instead of the endpoint to save a save the fields layout (`v3/contenttype/${contentTypeId}/fields/move`)
* The call to the wrong endpoint was causing that the relationship table was not updated with the changes for the 'required ' fields, even if the field table was updated.

### Checklist
- [x] Tests

